### PR TITLE
Fix Linux builds (again)

### DIFF
--- a/include/nana/paint/detail/image_bmp.hpp
+++ b/include/nana/paint/detail/image_bmp.hpp
@@ -82,7 +82,7 @@ namespace nana{	namespace paint
 						return false;
 
 					std::unique_ptr<char[]> buffer(new char[static_cast<int>(size)]);
-					
+
 					ifs.read(buffer.get(), size);
 					if(size == ifs.gcount())
 					{
@@ -94,7 +94,7 @@ namespace nana{	namespace paint
 
 							//Bitmap file is 4byte-aligned for each line.
 							std::size_t bytes_per_line;
-							const std::size_t height_pixels = abs(info->bmiHeader.biHeight);
+							const std::size_t height_pixels = std::abs(info->bmiHeader.biHeight);
 							if(0 == info->bmiHeader.biSizeImage)
 								bytes_per_line = (((info->bmiHeader.biWidth * info->bmiHeader.biBitCount + 31) & ~31) >> 3);
 							else
@@ -204,7 +204,7 @@ namespace nana{	namespace paint
 										d = dpend;
 										s -= bytes_per_line;
 									}
-								}							
+								}
 							}
 							else if(2 == info->bmiHeader.biBitCount)
 							{
@@ -257,7 +257,7 @@ namespace nana{	namespace paint
 										d = dpend;
 										s -= bytes_per_line;
 									}
-								}							
+								}
 							}
 							else if(1 == info->bmiHeader.biBitCount)
 							{
@@ -310,7 +310,7 @@ namespace nana{	namespace paint
 										d = dpend;
 										s -= bytes_per_line;
 									}
-								}							
+								}
 							}
 						}
 					}

--- a/source/gui/layout_utility.cpp
+++ b/source/gui/layout_utility.cpp
@@ -18,11 +18,11 @@ namespace nana
 	//overlap test if overlaped between r1 and r2
 	bool overlap(const rectangle& r1, const rectangle& r2)
 	{
-		if (r1.y + long long(r1.height) <= r2.y) return false;
-		if(r1.y >= r2.y + long long(r2.height)) return false;
+		if (r1.y + (long long)(r1.height) <= r2.y) return false;
+		if(r1.y >= r2.y + (long long)(r2.height)) return false;
 
-		if(r1.x + long long(r1.width) <= r2.x) return false;
-		if(r1.x >= r2.x + long long(r2.width)) return false;
+		if(r1.x + (long long)(r1.width) <= r2.x) return false;
+		if(r1.x >= r2.x + (long long)(r2.width)) return false;
 
 		return true;
 	}
@@ -255,7 +255,7 @@ namespace nana
 			ref_s.width = static_cast<unsigned>(ref_s.height * rate_input);
 		else if (rate_input > rate_ref)
 			ref_s.height = static_cast<unsigned>(ref_s.width / rate_input);
-		
+
 		return ref_s;
 	}
 


### PR DESCRIPTION
This fixes the following errors and warnings:

```
ryan@DevPC-LX:~/stuff/nana/build/makefile$ make -B GCC=clang++
...
clang++ -g -c ../../source/gui/layout_utility.cpp -o ../../source/gui/layout_utility.o -I../../include -I/usr/include/freetype2 -std=c++0x -Wall
../../source/gui/layout_utility.cpp:21:19: error: expected '(' for
      function-style cast or type construction
                if (r1.y + long long(r1.height) <= r2.y) return false;
                           ~~~~ ^
../../source/gui/layout_utility.cpp:22:26: error: expected '(' for
      function-style cast or type construction
                if(r1.y >= r2.y + long long(r2.height)) return false;
                                  ~~~~ ^
../../source/gui/layout_utility.cpp:24:18: error: expected '(' for
      function-style cast or type construction
                if(r1.x + long long(r1.width) <= r2.x) return false;
                          ~~~~ ^
../../source/gui/layout_utility.cpp:25:26: error: expected '(' for
      function-style cast or type construction
                if(r1.x >= r2.x + long long(r2.width)) return false;
                                  ~~~~ ^
4 errors generated.
make: *** [../../source/gui/layout_utility.o] Error 1
...
clang++ -g -c ../../source/paint/image.cpp -o ../../source/paint/image.o -I../../include -I/usr/include/freetype2 -std=c++0x -Wall
In file included from ../../source/paint/image.cpp:25:
../../include/nana/paint/detail/image_bmp.hpp:97:42: warning: absolute value
      function 'abs' given an argument of type 'long' but has parameter of type
      'int' which may cause truncation of value [-Wabsolute-value]
  ...const std::size_t height_pixels = abs(info->bmiHeader.biHeight);
                                       ^
../../include/nana/paint/detail/image_bmp.hpp:97:42: note: use function
      'std::abs' instead
  ...const std::size_t height_pixels = abs(info->bmiHeader.biHeight);
                                       ^~~
                                       std::abs
1 warning generated.
...
```

Oh, how I love Clang's diagnostic messages... ;)