### PR TITLE
fix: make panel and label have the same bgcolor as the owner

### DIFF
--- a/include/nana/gui/widgets/panel.hpp
+++ b/include/nana/gui/widgets/panel.hpp
@@ -44,11 +44,13 @@ namespace nana
 		panel(window wd, bool visible)
 		{
 			this->create(wd, rectangle(), visible);
+            bgcolor(API::bgcolor(wd));
 		}
 
 		panel(window wd, const nana::rectangle& r = rectangle(), bool visible = true)
 		{
 			this->create(wd, r, visible);
+            bgcolor(API::bgcolor(wd));
 		}
 
 		bool transparent() const

--- a/source/gui/widgets/label.cpp
+++ b/source/gui/widgets/label.cpp
@@ -765,23 +765,27 @@ namespace nana
 		label::label(window wd, bool visible)
 		{
 			create(wd, rectangle(), visible);
+            bgcolor(API::bgcolor(wd));
 		}
 
 		label::label(window wd, const nana::string& text, bool visible)
 		{
 			create(wd, rectangle(), visible);
+            bgcolor(API::bgcolor(wd));
 			caption(text);
 		}
 
 		label::label(window wd, const nana::char_t* text, bool visible)
 		{
 			create(wd, rectangle(), visible);
+            bgcolor(API::bgcolor(wd));
 			caption(text);
 		}
 
 		label::label(window wd, const rectangle& r, bool visible)
 		{
 			create(wd, r, visible);
+            bgcolor(API::bgcolor(wd));
 		}
 
 		label& label::transparent(bool enabled)


### PR DESCRIPTION
with this fix I can make this:
![group-gb](https://cloud.githubusercontent.com/assets/1911982/6750475/d00026fe-cefa-11e4-9a37-5d695ce62643.png)
[Compare with this](https://github.com/qPCR4vir/nana-demo/issues/1)
I also updated : https://github.com/qPCR4vir/nana-demo/blob/master/Examples/a_group_impl.cpp
![groups](https://cloud.githubusercontent.com/assets/1911982/6751039/5081e1a0-cf00-11e4-9afc-08fc6dbe6a01.png)
