### PR TITLE
fixing lookup error from gcc/mingw

### DIFF
--- a/include/nana/gui/widgets/panel.hpp
+++ b/include/nana/gui/widgets/panel.hpp
@@ -46,13 +46,13 @@ namespace nana
 		panel(window wd, bool visible)
 		{
 			this->create(wd, rectangle(), visible);
-			bgcolor(API::bgcolor(wd));
+			this->bgcolor(API::bgcolor(wd));
 		}
 
 		panel(window wd, const nana::rectangle& r = rectangle(), bool visible = true)
 		{
 			this->create(wd, r, visible);
-			bgcolor(API::bgcolor(wd));
+			this->bgcolor(API::bgcolor(wd));
 		}
 
 		bool transparent() const


### PR DESCRIPTION
small change to make nana compile with mingw again.

best regards, jan
^