### PR TITLE
modify readme and detect environment for biicode automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ Thumbs.db
 #Ignore files build by Visual Studio
 bii/build/*
 bii/cmake/*
+bii/deps/*
 *.obj
 *.exe
 *.pdb

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,11 @@ if(BIICODE)
     endif(CMAKE_COMPILER_IS_GNUCXX)
 
     # we'll use the default config file so we can iliminate the following macro definitions
+    if(MSVC)
+        # More MSVC specific compilation flags
+		add_definitions(-D_SCL_SECURE_NO_WARNINGS)
+		add_definitions(-D_CRT_SECURE_NO_DEPRECATE)
+    endif()
     
     add_biicode_targets()
     
@@ -52,6 +57,7 @@ if(WIN32)
 		add_definitions(-DSTD_CODECVT_NOT_SUPPORTED)
 		option(NANA_THREAD_NOT_SUPPORTED "Use this flag if MinGW version is older than 4.8.1" ON)
 		if(NANA_THREAD_NOT_SUPPORTED)
+            add_definitions(-DNANA_NO_CPP11)    # so that deploy.hpp will compile
 			add_definitions(-DSTD_THREAD_NOT_SUPPORTED)
 		endif()
 	endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,12 +4,10 @@
 #	Robert Hauck - Enable support for PNG/Freetype
 #   Qiangqiang Wu - Add biicode support
 
-if(NOT BIICODE)
-    project(nana)
-    cmake_minimum_required(VERSION 2.8)
-else()
+if(BIICODE)
+    # prepare BII_LIB_SRC
     set(LIB_SRC ${BII_LIB_SRC})
-    
+
     foreach(cpp ${BII_LIB_SRC})
         if(${cpp} MATCHES "/detail/(win32|linux_X11)/.+$")
             list(APPEND trash_files ${cpp})
@@ -17,7 +15,31 @@ else()
     endforeach()
 
     list(REMOVE_ITEM BII_LIB_SRC ${trash_files})
+    
+    if(WIN32)
+        file(GLOB_RECURSE platform_files "*/detail/win32/*")
+        list(APPEND BII_LIB_SRC ${platform_files})
+    elseif(UNIX)
+        file(GLOB_RECURSE platform_files "*/detail/linux_X11/*")
+        list(APPEND BII_LIB_SRC ${platform_files})
+    else()
+        message(FATAL_ERROR "Only Windows and Unix are supported for the moment")
+    endif()
+
+    # set compile  flags
+    if(CMAKE_COMPILER_IS_GNUCXX)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall")
+    endif(CMAKE_COMPILER_IS_GNUCXX)
+
+    # we'll use the default config file so we can iliminate the following macro definitions
+    
+    add_biicode_targets()
+    
+    return()
 endif()
+
+project(nana)
+cmake_minimum_required(VERSION 2.8)
 
 #Select platform automatically
 if(WIN32)
@@ -33,21 +55,12 @@ if(WIN32)
 			add_definitions(-DSTD_THREAD_NOT_SUPPORTED)
 		endif()
 	endif()
-    
-    if(BIICODE)
-        file(GLOB_RECURSE platform_files "*/detail/win32/*")
-        list(APPEND BII_LIB_SRC ${platform_files})
-    endif()
 endif()
 if(UNIX)
 	add_definitions(-DNANA_LINUX)
 	add_definitions(-DNANA_X11)
 	add_definitions(-DPLATFORM_SPEC_HPP=<nana/detail/linux_X11/platform_spec.hpp>)
 	add_definitions(-DSTD_CODECVT_NOT_SUPPORTED)
-    if(BIICODE)
-        file(GLOB_RECURSE platform_files "*/detail/linux_X11/*")
-        list(APPEND BII_LIB_SRC ${platform_files})
-    endif()
 endif()
 
 
@@ -75,84 +88,71 @@ if(NANA_UNICODE)
 	endif()
 endif()
 
-
-if(NOT BIICODE)
-    #Find PNG
-    if(UNIX)
-        find_package(Freetype)
-        if (FREETYPE_FOUND)
-            include_directories( ${FREETYPE_INCLUDE_DIRS})
-        endif()
+#Find PNG
+if(UNIX)
+    find_package(Freetype)
+    if (FREETYPE_FOUND)
+        include_directories( ${FREETYPE_INCLUDE_DIRS})
     endif()
+endif()
 
-    option(NANA_ENABLE_PNG "Enable the use of PNG" ON)
-    if(NANA_ENABLE_PNG)
-        add_definitions(-DNANA_ENABLE_PNG)
-
-        option(NANA_LIBPNG "Use the included libpng" ON)
-        if(NANA_LIBPNG)
-            add_definitions(-DNANA_LIBPNG)
-        else()
-            find_package(PNG)
-            if (PNG_FOUND)
-                include_directories( ${PNG_INCLUDE_DIRS})
-            endif()
-        endif()
-    endif()
-else()
+option(NANA_ENABLE_PNG "Enable the use of PNG" ON)
+if(NANA_ENABLE_PNG)
     add_definitions(-DNANA_ENABLE_PNG)
+
+    option(NANA_LIBPNG "Use the included libpng" ON)
+    if(NANA_LIBPNG)
+        add_definitions(-DNANA_LIBPNG)
+    else()
+        find_package(PNG)
+        if (PNG_FOUND)
+            include_directories( ${PNG_INCLUDE_DIRS})
+        endif()
+    endif()
 endif()
 
 #Copy our new config.hpp (with removed defines)
-if(NOT BIICODE)
-# I don't know how it works!!!
-message("Check config.hpp and copy")
 execute_process(COMMAND ${CMAKE_COMMAND} 
     -E copy_if_different 
     ${CMAKE_CURRENT_SOURCE_DIR}/build/cmake/config.hpp 
     ${CMAKE_CURRENT_SOURCE_DIR}/include/nana/)
-endif()
     
 if(CMAKE_COMPILER_IS_GNUCXX)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall")
 endif(CMAKE_COMPILER_IS_GNUCXX)
 
-if(BIICODE)
-    add_biicode_targets()
-else()
-    set(NANA_SOURCE_DIR ${CMAKE_SOURCE_DIR}/source)
-    set(NANA_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/include)
+set(NANA_SOURCE_DIR ${CMAKE_SOURCE_DIR}/source)
+set(NANA_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/include)
 
-    include_directories(${NANA_INCLUDE_DIR})
-    aux_source_directory(${NANA_SOURCE_DIR} NANA_SOURCE)
-    aux_source_directory(${NANA_SOURCE_DIR}/detail NANA_DETAIL_SOURCE)
-    aux_source_directory(${NANA_SOURCE_DIR}/filesystem NANA_FILESYSTEM_SOURCE)
-    aux_source_directory(${NANA_SOURCE_DIR}/audio NANA_AUDIO_SOURCE)
-    aux_source_directory(${NANA_SOURCE_DIR}/audio/detail NANA_AUDIO_DETAIL_SOURCE)
-    aux_source_directory(${NANA_SOURCE_DIR}/gui NANA_GUI_SOURCE)
-    aux_source_directory(${NANA_SOURCE_DIR}/gui/detail NANA_GUI_DETAIL_SOURCE)
-    aux_source_directory(${NANA_SOURCE_DIR}/gui/widgets NANA_GUI_WIDGETS_SOURCE)
-    aux_source_directory(${NANA_SOURCE_DIR}/gui/widgets/skeletons NANA_GUI_WIDGETS_SKELETONS_SOURCE)
-    aux_source_directory(${NANA_SOURCE_DIR}/paint NANA_PAINT_SOURCE)
-    aux_source_directory(${NANA_SOURCE_DIR}/paint/detail NANA_PAINT_DETAIL_SOURCE)
-    aux_source_directory(${NANA_SOURCE_DIR}/system NANA_SYSTEM_SOURCE)
-    aux_source_directory(${NANA_SOURCE_DIR}/threads NANA_THREADS_SOURCE)
+include_directories(${NANA_INCLUDE_DIR})
+aux_source_directory(${NANA_SOURCE_DIR} NANA_SOURCE)
+aux_source_directory(${NANA_SOURCE_DIR}/detail NANA_DETAIL_SOURCE)
+aux_source_directory(${NANA_SOURCE_DIR}/filesystem NANA_FILESYSTEM_SOURCE)
+aux_source_directory(${NANA_SOURCE_DIR}/audio NANA_AUDIO_SOURCE)
+aux_source_directory(${NANA_SOURCE_DIR}/audio/detail NANA_AUDIO_DETAIL_SOURCE)
+aux_source_directory(${NANA_SOURCE_DIR}/gui NANA_GUI_SOURCE)
+aux_source_directory(${NANA_SOURCE_DIR}/gui/detail NANA_GUI_DETAIL_SOURCE)
+aux_source_directory(${NANA_SOURCE_DIR}/gui/widgets NANA_GUI_WIDGETS_SOURCE)
+aux_source_directory(${NANA_SOURCE_DIR}/gui/widgets/skeletons NANA_GUI_WIDGETS_SKELETONS_SOURCE)
+aux_source_directory(${NANA_SOURCE_DIR}/paint NANA_PAINT_SOURCE)
+aux_source_directory(${NANA_SOURCE_DIR}/paint/detail NANA_PAINT_DETAIL_SOURCE)
+aux_source_directory(${NANA_SOURCE_DIR}/system NANA_SYSTEM_SOURCE)
+aux_source_directory(${NANA_SOURCE_DIR}/threads NANA_THREADS_SOURCE)
 
-    add_library(${PROJECT_NAME} ${NANA_SOURCE}
-                                ${NANA_DETAIL_SOURCE}
-                                ${NANA_FILESYSTEM_SOURCE}
-                                ${NANA_AUDIO_SOURCE}
-                                ${NANA_AUDIO_DETAIL_SOURCE}
-                                ${NANA_GUI_SOURCE}
-                                ${NANA_GUI_DETAIL_SOURCE}
-                                ${NANA_GUI_WIDGETS_SOURCE}
-                                ${NANA_GUI_WIDGETS_SKELETONS_SOURCE}
-                                ${NANA_PAINT_SOURCE}
-                                ${NANA_PAINT_DETAIL_SOURCE}
-                                ${NANA_SYSTEM_SOURCE}
-                                ${NANA_THREADS_SOURCE})                        
-    install(TARGETS ${PROJECT_NAME}
-                ARCHIVE DESTINATION lib
-                LIBRARY DESTINATION lib)
-    install(DIRECTORY ${NANA_INCLUDE_DIR}/nana DESTINATION include)
-endif()
+add_library(${PROJECT_NAME} ${NANA_SOURCE}
+                            ${NANA_DETAIL_SOURCE}
+                            ${NANA_FILESYSTEM_SOURCE}
+                            ${NANA_AUDIO_SOURCE}
+                            ${NANA_AUDIO_DETAIL_SOURCE}
+                            ${NANA_GUI_SOURCE}
+                            ${NANA_GUI_DETAIL_SOURCE}
+                            ${NANA_GUI_WIDGETS_SOURCE}
+                            ${NANA_GUI_WIDGETS_SKELETONS_SOURCE}
+                            ${NANA_PAINT_SOURCE}
+                            ${NANA_PAINT_DETAIL_SOURCE}
+                            ${NANA_SYSTEM_SOURCE}
+                            ${NANA_THREADS_SOURCE})                        
+install(TARGETS ${PROJECT_NAME}
+            ARCHIVE DESTINATION lib
+            LIBRARY DESTINATION lib)
+install(DIRECTORY ${NANA_INCLUDE_DIR}/nana DESTINATION include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ else()
     set(LIB_SRC ${BII_LIB_SRC})
     
     foreach(cpp ${BII_LIB_SRC})
-        if(${cpp} MATCHES "(include/nana|source)/detail/[A-Za-z0-9_]+/.+$")
+        if(${cpp} MATCHES "/detail/(win32|linux_X11)/.+$")
             list(APPEND trash_files ${cpp})
         endif()
     endforeach()
@@ -100,12 +100,18 @@ if(NOT BIICODE)
         endif()
     endif()
 else()
-    add_definitions(-DNANA_LIBPNG)
     add_definitions(-DNANA_ENABLE_PNG)
 endif()
 
 #Copy our new config.hpp (with removed defines)
-execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/build/cmake/config.hpp ${CMAKE_CURRENT_SOURCE_DIR}/include/nana/)
+if(NOT BIICODE)
+# I don't know how it works!!!
+message("Check config.hpp and copy")
+execute_process(COMMAND ${CMAKE_COMMAND} 
+    -E copy_if_different 
+    ${CMAKE_CURRENT_SOURCE_DIR}/build/cmake/config.hpp 
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/nana/)
+endif()
     
 if(CMAKE_COMPILER_IS_GNUCXX)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall")

--- a/README.md
+++ b/README.md
@@ -9,6 +9,21 @@ Nana is licensed under the [Boost Software License].
 
 [Boost Software License]: http://www.boost.org/LICENSE_1_0.txt
 
+## Biicode
+Nana is available in biicode, download biicode and try the nana example:
+
+```
+> mkdir try-nana
+> cd try-nana
+> bii init
+> bii open qiangwu/nana-example
+> bii find
+> bii build
+> cd bin
+```
+
+Run it! All dependencies will be resovled automatically by biicode! Amazing, isn't it?
+
 ## Support
 
 The best way to get help with Nana library is by visiting http://nanapro.org/help.htm

--- a/biicode.conf
+++ b/biicode.conf
@@ -1,9 +1,7 @@
 # Biicode configuration file
 
 [requirements]
-    # Blocks and versions this block depends on e.g.
-    # user/depblock1: 3
-    # user2/depblock2(track) @tag
+	 glenn/png: 6
 
 [parent]
     # The parent version of this block. Must match folder name. E.g.
@@ -21,7 +19,8 @@
     # Manual adjust file implicit dependencies, add (+), remove (-), or overwrite (=)
     # hello.h + hello_imp.cpp hello_imp2.cpp
     # *.h + *.cpp
-    include/nana/config.hpp + build/cmake/config.hpp
+    include/nana/config.hpp + include/*
+    include/nana/config.hpp + source/*
 
 [mains]
     # Manual adjust of files that define an executable
@@ -40,6 +39,7 @@
 [includes]
     # Mapping of include patterns to external blocks
     # hello*.h: user3/depblock  # includes will be processed as user3/depblock/hello*.h
+    png.h: glenn/png
 
 [data]
     # Manually define data files dependencies, that will be copied to bin for execution

--- a/include/nana/config.hpp
+++ b/include/nana/config.hpp
@@ -23,7 +23,6 @@
 	#if defined(__MINGW32__)
 		#define NANA_MINGW
 		#define STD_CODECVT_NOT_SUPPORTED
-		//#define STD_THREAD_NOT_SUPPORTED	//Use this flag if MinGW version is older than 4.8.1
 	#endif
 #elif (defined(linux) || defined(__linux) || defined(__linux__) || defined(__GNU__) || defined(__GLIBC__)) && !defined(_CRAYC)
 //Linux:
@@ -31,13 +30,29 @@
 	#define NANA_X11	1
 	#define PLATFORM_SPEC_HPP <nana/detail/linux_X11/platform_spec.hpp>
 	#define STD_CODECVT_NOT_SUPPORTED
+#else
+#   error   "Only Windows and Unix are support now"
+#endif
+
+// C++11 detection
+#if defined(__GNUC_MINOR__)
+#   if __GNUC_MINOR__ < 8
+#       define NANA_NO_CPP11
+#   endif
+#elif _MSC_VER < 1700
+#   define NANA_NO_CPP11
+#endif
+
+#if defined(NANA_NO_CPP11)
+#   define STD_THREAD_NOT_SUPPORTED
 #endif
 
 //Here defines some flags that tell Nana what features will be supported.
 
-#define NANA_UNICODE
+#define NANA_ENABLE_PNG
+#define NANA_UNICODE    // always use unicode, don't make users confusing!
 
-#if defined(NANA_UNICODE) && defined(NANA_WINDOWS)
+#if defined(NANA_WINDOWS)
 	#ifndef _UNICODE
 		#define _UNICODE
 	#endif
@@ -46,14 +61,5 @@
 		#define UNICODE
 	#endif
 #endif
-
-//Support for PNG
-//	Comment it to disable the feature of support for PNG.
-//#define NANA_ENABLE_PNG
-#if defined(NANA_ENABLE_PNG)
-	//Comment it to use libpng from operating system.
-	#define NANA_LIBPNG
-#endif
-
 
 #endif	//NANA_CONFIG_HPP

--- a/include/nana/deploy.hpp
+++ b/include/nana/deploy.hpp
@@ -24,7 +24,7 @@
 #endif
 
 //Implement workarounds for MinGW
-#if defined(NANA_MINGW) && __GNUC_MINOR__ < 8
+#if NANA_NO_CPP11
 namespace std
 {
 	//Workaround for no implemenation of std::stoi in MinGW.

--- a/include/nana/std_condition_variable.hpp
+++ b/include/nana/std_condition_variable.hpp
@@ -2,7 +2,7 @@
 #define NANA_STD_CONDITION_VARIABLE_HPP
 #include <nana/config.hpp>
 
-#if NANA_NO_CPP11
+#if STD_THREAD_NOT_SUPPORTED
 
 #include <boost/thread/condition_variable.hpp>
 namespace std

--- a/include/nana/std_condition_variable.hpp
+++ b/include/nana/std_condition_variable.hpp
@@ -2,11 +2,17 @@
 #define NANA_STD_CONDITION_VARIABLE_HPP
 #include <nana/config.hpp>
 
-#if defined(STD_THREAD_NOT_SUPPORTED)
+#if defined(STD_THREAD_NOT_SUPPORTED) && !defined(NANA_MINGW) || __GNUC_MINOR__ < 8
+
 #include <boost/thread/condition_variable.hpp>
 namespace std
 {
     typedef boost::condition_variable condition_variable;
 }
+
+#else
+
+#include <condition_variable>    
+
 #endif
 #endif // NANA_STD_CONDITION_VARIABLE_HPP

--- a/include/nana/std_condition_variable.hpp
+++ b/include/nana/std_condition_variable.hpp
@@ -2,7 +2,7 @@
 #define NANA_STD_CONDITION_VARIABLE_HPP
 #include <nana/config.hpp>
 
-#if defined(STD_THREAD_NOT_SUPPORTED) && !defined(NANA_MINGW) || __GNUC_MINOR__ < 8
+#if NANA_NO_CPP11
 
 #include <boost/thread/condition_variable.hpp>
 namespace std

--- a/include/nana/std_mutex.hpp
+++ b/include/nana/std_mutex.hpp
@@ -2,7 +2,8 @@
 #define NANA_STD_MUTEX_HPP
 #include <nana/config.hpp>
 
-#if defined(STD_THREAD_NOT_SUPPORTED)
+#if defined(STD_THREAD_NOT_SUPPORTED) && !defined(NANA_MINGW) || __GNUC_MINOR__ < 8
+
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/recursive_mutex.hpp>
 #include <boost/thread/locks.hpp>
@@ -18,5 +19,10 @@ namespace std
     typedef boost::mutex mutex;
     typedef boost::recursive_mutex recursive_mutex;
 }
+#else
+
+#include <mutex>
+
 #endif
+
 #endif // NANA_STD_MUTEX_HPP

--- a/include/nana/std_mutex.hpp
+++ b/include/nana/std_mutex.hpp
@@ -2,7 +2,7 @@
 #define NANA_STD_MUTEX_HPP
 #include <nana/config.hpp>
 
-#if defined(STD_THREAD_NOT_SUPPORTED) && !defined(NANA_MINGW) || __GNUC_MINOR__ < 8
+#if NANA_NO_CPP11
 
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/recursive_mutex.hpp>

--- a/include/nana/std_mutex.hpp
+++ b/include/nana/std_mutex.hpp
@@ -2,7 +2,7 @@
 #define NANA_STD_MUTEX_HPP
 #include <nana/config.hpp>
 
-#if NANA_NO_CPP11
+#if STD_THREAD_NOT_SUPPORTED
 
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/recursive_mutex.hpp>

--- a/include/nana/std_thread.hpp
+++ b/include/nana/std_thread.hpp
@@ -2,7 +2,7 @@
 #define NANA_STD_THREAD_HPP
 #include <nana/config.hpp>
 
-#if defined(STD_THREAD_NOT_SUPPORTED) && !defined(NANA_MINGW) || __GNUC_MINOR__ < 8
+#if NANA_NO_CPP11
 #include <boost/thread.hpp>
 namespace std
 {

--- a/include/nana/std_thread.hpp
+++ b/include/nana/std_thread.hpp
@@ -2,12 +2,16 @@
 #define NANA_STD_THREAD_HPP
 #include <nana/config.hpp>
 
-#if defined(STD_THREAD_NOT_SUPPORTED)
+#if defined(STD_THREAD_NOT_SUPPORTED) && !defined(NANA_MINGW) || __GNUC_MINOR__ < 8
 #include <boost/thread.hpp>
 namespace std
 {
     typedef boost::thread thread;
 }
+#else
+
+#include <thread>    
+
 #endif
 
 #endif // NANA_STD_THREAD_HPP

--- a/include/nana/std_thread.hpp
+++ b/include/nana/std_thread.hpp
@@ -2,7 +2,7 @@
 #define NANA_STD_THREAD_HPP
 #include <nana/config.hpp>
 
-#if NANA_NO_CPP11
+#if STD_THREAD_NOT_SUPPORTED
 #include <boost/thread.hpp>
 namespace std
 {

--- a/source/deploy.cpp
+++ b/source/deploy.cpp
@@ -23,7 +23,7 @@
 	#include PLATFORM_SPEC_HPP
 #endif
 
-#if defined(NANA_MINGW) && __GNUC_MINOR__ < 8
+#if NANA_NO_CPP11
 #include <sstream>
 namespace std
 {


### PR DESCRIPTION
1. Add Biicode example in README
2. Eliminate macro redefinition warnings when used with Biicode. When used with Biicode, the default config.hpp will be used which will automatically detect its environment. When used individually(via raw CMake), nothing changes.