### PR TITLE
Pressing Shift+Tab moves input focus to the previous control.

### DIFF
--- a/source/gui/detail/win32/bedrock.cpp
+++ b/source/gui/detail/win32/bedrock.cpp
@@ -1369,7 +1369,7 @@ namespace detail
 					{
 						if((wParam == 9) && (false == (msgwnd->flags.tab & tab_type::eating))) //Tab
 						{
-							auto the_next = brock.wd_manager.tabstop(msgwnd, true);
+							auto the_next = brock.wd_manager.tabstop(msgwnd, (::GetKeyState(VK_SHIFT) >= 0));
 							if(the_next)
 							{
 								brock.wd_manager.set_focus(the_next, false);


### PR DESCRIPTION
I modified below code so that pressing Shift+Tab keys changes control focus to previous tabstop.
File : source\gui\detail\win32\bedrock.cpp
Func : nana::detail::Bedrock_WIN32_WindowProc
```c+++
// case WM_KEYDOWN:
auto the_next = brock.wd_manager.tabstop(msgwnd, (::GetKeyState(VK_SHIFT) >= 0));
```
https://msdn.microsoft.com/en-us/library/windows/desktop/dn742465
