### PR TITLE
trivial fix for compiler warning

### DIFF
--- a/include/nana/gui/widgets/listbox.hpp
+++ b/include/nana/gui/widgets/listbox.hpp
@@ -248,7 +248,7 @@ namespace nana
 					auto && cells = ores.move_cells();
 					auto cols = columns();
 					cells.resize(cols);
-					for (auto pos = 0; pos < cols; ++pos)
+					for (auto pos = 0u; pos < cols; ++pos)
 					{
 						auto & el = cells[pos];
 						if (el.text.size() == 1 && el.text[0] == nana::char_t(0))


### PR DESCRIPTION
Here is an excerpt from output window of VS2013.

1>c:\libs\nana\include\nana\gui\widgets\listbox.hpp(251): warning C4018: '<' : signed/unsigned mismatch (..\form_do_you_even_lift.cpp)
1>          c:\projects\bro\form_do_you_even_lift.cpp(646) : see reference to function template instantiation 'nana::drawerbase::listbox::item_proxy &nana::drawerbase::listbox::item_proxy::resolve_from<Data>(const T &)' being compiled
1>          with
1>          [
1>              T=Data
1>          ]