### PR TITLE
Fix Clang builds (again)

### DIFF
--- a/source/gui/detail/bedrock_pi.cpp
+++ b/source/gui/detail/bedrock_pi.cpp
@@ -22,6 +22,7 @@
 #include <nana/gui/detail/native_window_interface.hpp>
 #include <nana/gui/layout_utility.hpp>
 #include <nana/gui/detail/element_store.hpp>
+#include <algorithm>
 
 namespace nana
 {

--- a/source/gui/detail/window_manager.cpp
+++ b/source/gui/detail/window_manager.cpp
@@ -21,6 +21,7 @@
 #include <nana/gui/layout_utility.hpp>
 #include <nana/gui/detail/effects_renderer.hpp>
 #include <stdexcept>
+#include <algorithm>
 
 namespace nana
 {

--- a/source/gui/msgbox.cpp
+++ b/source/gui/msgbox.cpp
@@ -774,7 +774,7 @@ namespace nana
 		impl->label.format(true);
 
 		//get the longest value
-		auto longest = (std::abs((impl->begin < 0 ? impl->begin * 10 : impl->begin)) < std::abs(impl->last < 0 ? impl->last * 10 : impl->last) ? impl->last : impl->begin);
+		auto longest = (std::abs(static_cast<int>(impl->begin < 0 ? impl->begin * 10 : impl->begin)) < std::abs(static_cast<int>(impl->last < 0 ? impl->last * 10 : impl->last)) ? impl->last : impl->begin);
 		paint::graphics graph{ ::nana::size{ 10, 10 } };
 		auto value_px = graph.text_extent_size(std::to_wstring(longest)).width + 34;
 


### PR DESCRIPTION
This fixes the following:

- An ambiguous call to `std::abs` (of course, it's not really ambiguous; glibc is just broken)
- `algorithm` wasn't included, so the calls weren't getting resolved correctly
