### PR TITLE
remove some warnings with VS2013

### DIFF
--- a/include/nana/datetime.hpp
+++ b/include/nana/datetime.hpp
@@ -41,6 +41,7 @@ namespace nana
 
 		int day_of_week() const;
 		const value & read() const;
+		void set(const std::tm&);
 
 		static int day_of_week(int year, int month, int day);
 		static unsigned year_days(unsigned year);	///< the number of days in the specified year.
@@ -67,6 +68,7 @@ namespace nana
 		time(const std::tm&);
 		time(unsigned hour, unsigned minute, unsigned second);
 		const value& read() const;
+		void set(const std::tm&);
 	private:
 		value	value_;
 	};//end class time

--- a/include/nana/deploy.hpp
+++ b/include/nana/deploy.hpp
@@ -91,6 +91,20 @@ namespace nana
 {
 	std::size_t strlen(const char_t* str);
 	char_t* strcpy(char_t* dest, const char_t* source);
+#ifdef _MSC_VER
+	template <size_t N>
+	inline char* strcpy(char (&dest)[N], const char* source)
+	{
+		::strncpy_s(dest, source, _TRUNCATE);
+		return dest;
+	}
+	template <size_t N>
+	inline wchar_t* strcpy(wchar_t (&dest)[N], const wchar_t* source)
+	{
+		::wcsncpy_s(dest, source, _TRUNCATE);
+		return dest;
+	}
+#endif // #ifdef _MSC_VER
 }
 
 #if defined(NANA_WINDOWS)

--- a/source/charset.cpp
+++ b/source/charset.cpp
@@ -24,7 +24,7 @@
 	#include <codecvt>
 #endif
 
-#if defined(NANA_MINGW)
+#if defined(NANA_WINDOWS)
 	#include <windows.h>
 #endif
 
@@ -54,7 +54,7 @@ namespace nana
 				mbstr.clear();
 				return true;
 			}
-#if defined(NANA_MINGW)
+#if defined(NANA_WINDOWS)
 			int bytes = ::WideCharToMultiByte(CP_ACP, 0, s, -1, 0, 0, 0, 0);
 			if(bytes > 1)
 			{
@@ -87,7 +87,7 @@ namespace nana
 				wcstr.clear();
 				return true;
 			}
-#if defined(NANA_MINGW) 
+#if defined(NANA_WINDOWS)
 			int chars = ::MultiByteToWideChar(CP_ACP, 0, s, -1, 0, 0);
 			if(chars > 1)
 			{
@@ -119,7 +119,7 @@ namespace nana
 				wcstr.clear();
 				return true;
 			}
-#if defined(NANA_MINGW) 
+#if defined(NANA_WINDOWS)
 			int chars = ::MultiByteToWideChar(CP_ACP, 0, s, -1, 0, 0);
 			if(chars > 1)
 			{

--- a/source/datetime.cpp
+++ b/source/datetime.cpp
@@ -14,24 +14,47 @@
 #if defined(NANA_WINDOWS)
 	#include <windows.h>
 #endif
+#include <cassert>
+
+namespace {
+	void localtime(struct tm& tm)
+	{
+#if defined(NANA_WINDOWS)
+		time_t t;
+		::time(&t);
+		if(localtime_s(&tm, &t) != 0)
+		{
+			assert(false);
+		}
+#else
+		time_t t = std::time(nullptr);
+		struct tm * tm_addr = std::localtime(&t);
+		assert(tm_addr);
+		tm = *tm_addr;
+#endif
+	}
+} // namespace anonymous
 
 namespace nana
 {
 	//class date
-		date::date()
-		{
-			time_t t = std::time(nullptr);
-			struct tm * tm_addr = std::localtime(&t);
-			value_.year = tm_addr->tm_year + 1900;
-			value_.month = tm_addr->tm_mon + 1;
-			value_.day = tm_addr->tm_mday;
-		}
-
-		date::date(const std::tm& t)
+		void date::set(const std::tm& t)
 		{
 			value_.year = t.tm_year + 1900;
 			value_.month = t.tm_mon + 1;
 			value_.day = t.tm_mday;
+		}
+
+		date::date()
+		{
+			struct tm t;
+			localtime(t);
+			set(t);
+		}
+
+		date::date(const std::tm& t)
+		{
+			set(t);
 		}
 
 		date::date(int year, int month, int day)
@@ -47,11 +70,9 @@ namespace nana
 				}
 			}
 
-			time_t t = std::time(0);
-			struct tm * tm_addr = std::localtime(&t);
-			value_.year = tm_addr->tm_year + 1900;
-			value_.month = tm_addr->tm_mon + 1;
-			value_.day = tm_addr->tm_mday;
+			struct tm t;
+			localtime(t);
+			set(t);
 		}
 
 		date date::operator - (int off) const
@@ -235,13 +256,18 @@ namespace nana
 	//end class date
 
 	//class time
+		void time::set(const std::tm& t)
+		{
+			value_.hour = t.tm_hour;
+			value_.minute = t.tm_min;
+			value_.second = t.tm_sec;
+		}
+
 		time::time()
 		{
-			time_t t = ::time(0);
-			struct tm * tm_addr = ::localtime(&t);
-			value_.hour = tm_addr->tm_hour;
-			value_.minute = tm_addr->tm_min;
-			value_.second = tm_addr->tm_sec;
+			struct tm t;
+			localtime(t);
+			set(t);
 		}
 
 		time::time(const std::tm& t)
@@ -258,12 +284,11 @@ namespace nana
 				value_.hour = hour;
 				value_.minute = minute;
 				value_.second = second;
+				return;
 			}
-			time_t t = ::time(0);
-			struct tm * tm_addr = ::localtime(&t);
-			value_.hour = tm_addr->tm_hour;
-			value_.minute = tm_addr->tm_min;
-			value_.second = tm_addr->tm_sec;
+			struct tm t;
+			localtime(t);
+			set(t);
 		}
 
 		const time::value& time::read() const

--- a/source/detail/win32/platform_spec.cpp
+++ b/source/detail/win32/platform_spec.cpp
@@ -16,6 +16,7 @@
 #include PLATFORM_SPEC_HPP
 #include <shellapi.h>
 #include <stdexcept>
+#include <VersionHelpers.h>
 
 namespace nana
 {
@@ -184,11 +185,10 @@ namespace detail
 		NONCLIENTMETRICS metrics = {};
 		metrics.cbSize = sizeof metrics;
 #if(WINVER >= 0x0600)
-		OSVERSIONINFO osvi = {};
-		osvi.dwOSVersionInfoSize = sizeof(osvi);
-		::GetVersionEx(&osvi);
-		if (osvi.dwMajorVersion < 6)
+		if(!IsWindowsVistaOrGreater())
+		{
 			metrics.cbSize -= sizeof(metrics.iPaddedBorderWidth);
+		}
 #endif
 		::SystemParametersInfo(SPI_GETNONCLIENTMETRICS, sizeof metrics, &metrics, 0);
 		def_font_ptr_ = make_native_font(metrics.lfMessageFont.lfFaceName, font_size_to_height(9), 400, false, false, false);


### PR DESCRIPTION
Hi, I edited nana's code a little bit to remove some warnings with VS2013.
And in time::time(unsigned hour, unsigned minute, unsigned second) constructor, I added return statement if args are valid.
