### PR TITLE
Several modifications

### DIFF
--- a/include/nana/gui/detail/native_window_interface.hpp
+++ b/include/nana/gui/detail/native_window_interface.hpp
@@ -45,6 +45,8 @@ namespace detail
 		static void enable_dropfiles(native_window_type, bool);
 		static void enable_window(native_window_type, bool);
 		static bool window_icon(native_window_type, const paint::image&);
+		// (On Windows) The system displays the large icon in the ALT+TAB dialog box, and the small icon in the window caption.
+		static bool window_icon(native_window_type, const paint::image& big_icon, const paint::image& small_icon);
 		static void activate_owner(native_window_type);
 		static void activate_window(native_window_type);
 		static void close_window(native_window_type);

--- a/include/nana/gui/detail/widget_notifier_interface.hpp
+++ b/include/nana/gui/detail/widget_notifier_interface.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <memory>
+#include <nana/gui/widgets/widget.hpp>
+
+namespace nana {
+namespace detail {
+
+class widget_notifier_interface {
+public:
+	virtual widget* widget_ptr() const = 0;
+	virtual void destroy() = 0;
+	virtual std::wstring caption() = 0;
+	virtual void caption(std::wstring text) = 0;
+	
+	static std::unique_ptr<widget_notifier_interface> get_notifier(widget* wdg);
+private:
+	widget::notifier* p;
+};
+
+} // namespace detail
+} // namespace nana

--- a/include/nana/gui/detail/window_manager.hpp
+++ b/include/nana/gui/detail/window_manager.hpp
@@ -112,7 +112,6 @@ namespace detail
 		void signal_fire_caption(core_window_t*, const nana::char_t*);
 		nana::string signal_fire_caption(core_window_t*);
 		void event_filter(core_window_t*, bool is_make, event_code);
-		void default_icon(const nana::paint::image&);
 
 		bool available(core_window_t*);
 		bool available(core_window_t *, core_window_t*);
@@ -133,7 +132,10 @@ namespace detail
 		//@brief:	Delete window handle, the handle type must be a root and a frame.
 		void destroy_handle(core_window_t*);
 
+		void default_icon(const paint::image&);
+		void default_icon(const paint::image& big_icon, const paint::image& small_icon);
 		void icon(core_window_t*, const paint::image&);
+		void icon(core_window_t*, const paint::image& big_icon, const paint::image& small_icon);
 
 		//show
 		//@brief: show or hide a window

--- a/include/nana/gui/programming_interface.hpp
+++ b/include/nana/gui/programming_interface.hpp
@@ -120,7 +120,10 @@ namespace API
 	}
 
 	void window_icon_default(const paint::image&);
+	void window_icon_default(const paint::image& big_icon, const paint::image& small_icon);
 	void window_icon(window, const paint::image&);
+	void window_icon(window, const paint::image& big_icon, const paint::image& small_icon);
+	
 	bool empty_window(window);		///< Determines whether a window is existing.
 	bool is_window(window);			///< Determines whether a window is existing, equal to !empty_window.
 	void enable_dropfiles(window, bool);

--- a/include/nana/gui/widgets/label.hpp
+++ b/include/nana/gui/widgets/label.hpp
@@ -65,6 +65,8 @@ namespace nana
 		label& format(bool);		///< Switches the format mode of the widget.
 		label& add_format_listener(std::function<void(command, const nana::string&)>);
 
+		void relate(widget& w);	// as same as the "for" attribute of a label
+
 		/// \briefReturn the size of the text. If *allowed_width_in_pixel* is not zero, returns a 
 		/// "corrected" size that changes lines to fit the text into the specified width
 		nana::size measure(unsigned allowed_width_in_pixel) const;

--- a/include/nana/gui/widgets/skeletons/text_editor.hpp
+++ b/include/nana/gui/widgets/skeletons/text_editor.hpp
@@ -157,8 +157,8 @@ namespace nana{	namespace widgets
 
 			void set_accept(std::function<bool(char_type)>);
 			void set_accept(accepts);
-			bool respond_char(char_type);
-			bool respond_key(char_type);
+			bool respond_char(const arg_keyboard& arg);
+			bool respond_key(const arg_keyboard& arg);
 
 			void typeface_changed();
 
@@ -286,6 +286,8 @@ namespace nana{	namespace widgets
 			unsigned _m_char_by_pixels(const nana::char_t*, std::size_t len, unsigned* pxbuf, int str_px, int pixels, bool is_rtl);
 			unsigned _m_pixels_by_char(const nana::string&, std::size_t pos) const;
 			static bool _m_is_right_text(const unicode_bidi::entity&);
+			void _handle_move_key(const arg_keyboard& arg);
+
 		private:
 			std::unique_ptr<editor_behavior_interface> behavior_;
 			undoable<command>	undo_;

--- a/include/nana/paint/detail/image_bmp.hpp
+++ b/include/nana/paint/detail/image_bmp.hpp
@@ -75,6 +75,12 @@ namespace nana{	namespace paint
 				this->close();
 			}
 
+			bool open(void* buff, size_t sz)
+			{
+				// TODO: read a BMP file from memory
+				return false;
+			}
+
 			bool open(const nana::char_t* filename)
 			{
 				if(nullptr == filename) return false;

--- a/include/nana/paint/detail/image_ico.hpp
+++ b/include/nana/paint/detail/image_ico.hpp
@@ -23,6 +23,7 @@ namespace nana{	namespace paint
 			image_ico(bool is_ico);
 
 			bool open(const nana::char_t* filename);
+			bool open(void* buff, size_t sz);
 			bool alpha_channel() const;
 			bool empty() const;
 			void close();

--- a/include/nana/paint/detail/image_impl_interface.hpp
+++ b/include/nana/paint/detail/image_impl_interface.hpp
@@ -16,6 +16,7 @@ namespace nana{	namespace paint{
 		typedef nana::paint::graphics& graph_reference;
 		virtual ~image_impl_interface() = 0;	//The destructor is defined in ../image.cpp
 		virtual bool open(const nana::char_t* filename) = 0;
+		virtual bool open(void* buff, size_t sz) = 0; // reads image from memory
 		virtual bool alpha_channel() const = 0;
 		virtual bool empty() const = 0;
 		virtual void close() = 0;

--- a/include/nana/paint/graphics.hpp
+++ b/include/nana/paint/graphics.hpp
@@ -130,7 +130,7 @@ namespace nana
 			void setsta();      ///<  	Clears the status if the graphics object had been changed
 			void set_changed();
 			void release();
-			void save_as_file(const char*);
+			void save_as_file(const char*) const;	// saves image as a bitmap file
 
 			void set_color(const ::nana::color&);
 			void set_text_color(const ::nana::color&);

--- a/include/nana/paint/image.hpp
+++ b/include/nana/paint/image.hpp
@@ -37,6 +37,7 @@ namespace paint
 		image& operator=(const image& rhs);
 		image& operator=(image&&);
 		bool open(const nana::string& filename);
+		bool open_icon(void* buff, size_t sz);	// opens a icon from memory
 		bool empty() const;
 		operator unspecified_bool_t() const;
 		void close();

--- a/source/gui/detail/native_window_interface.cpp
+++ b/source/gui/detail/native_window_interface.cpp
@@ -537,6 +537,30 @@ namespace nana{
 			return false;
 		}
 
+		bool native_interface::window_icon(native_window_type wd, const paint::image& big_icon, const paint::image& small_icon)
+		{
+#if defined(NANA_WINDOWS)
+			HICON h_big_icon = paint::image_accessor::icon(big_icon);
+			HICON h_small_icon = paint::image_accessor::icon(small_icon);
+			if (h_big_icon || h_small_icon)
+			{
+				nana::detail::platform_spec::instance().keep_window_icon(wd, (!big_icon.empty() ? big_icon : small_icon));
+				if (h_big_icon) {
+					::SendMessage(reinterpret_cast<HWND>(wd), WM_SETICON, ICON_BIG, reinterpret_cast<LPARAM>(h_big_icon));
+				}
+				if (h_small_icon) {
+					::SendMessage(reinterpret_cast<HWND>(wd), WM_SETICON, ICON_SMALL, reinterpret_cast<WPARAM>(h_small_icon));
+				}
+				return true;
+			}
+#elif defined(NANA_X11)
+			return window_icon(wd, big_icon);
+#endif
+			return false;
+		}
+
+
+
 		void native_interface::activate_owner(native_window_type wd)
 		{
 #if defined(NANA_WINDOWS)

--- a/source/gui/detail/win32/bedrock.cpp
+++ b/source/gui/detail/win32/bedrock.cpp
@@ -1400,10 +1400,10 @@ namespace detail
 							{
 								if (!tstop_wd->flags.ignore_mouse_focus)
 								{
+									root_runtime->condition.tabstop_focus_changed = true;
 									brock.wd_manager.set_focus(tstop_wd, false);
 									brock.wd_manager.do_lazy_refresh(msgwnd, false);
 									brock.wd_manager.do_lazy_refresh(tstop_wd, true);
-									root_runtime->condition.tabstop_focus_changed = true;
 									break;
 								}
 

--- a/source/gui/detail/window_manager.cpp
+++ b/source/gui/detail/window_manager.cpp
@@ -43,7 +43,8 @@ namespace detail
 				root_register	misc_register;
 				handle_manager<core_window_t*, window_manager, window_handle_deleter>	wd_register;
 				signal_manager	signal;
-				paint::image default_icon;
+				paint::image default_icon_big;
+				paint::image default_icon_small;
 			};
 		//end struct wdm_private_impl
 
@@ -199,11 +200,6 @@ namespace detail
 			}
 		}
 
-		void window_manager::default_icon(const paint::image& img)
-		{
-			impl_->default_icon = img;
-		}
-
 		bool window_manager::available(core_window_t* wd)
 		{
 			return impl_->wd_register.available(wd);
@@ -264,7 +260,7 @@ namespace detail
 					insert_frame(owner, wd);
 
 				bedrock::inc_window(wd->thread_id);
-				this->icon(wd, impl_->default_icon);
+				this->icon(wd, impl_->default_icon_big, impl_->default_icon_small);
 				return wd;
 			}
 			return nullptr;
@@ -404,6 +400,18 @@ namespace detail
 			}
 		}
 
+		void window_manager::default_icon(const paint::image& img)
+		{
+			impl_->default_icon_big = img;
+			impl_->default_icon_small = img;
+		}
+
+		void window_manager::default_icon(const nana::paint::image& big, const nana::paint::image& small)
+		{
+			impl_->default_icon_big = big;
+			impl_->default_icon_small = small;
+		}
+
 		void window_manager::icon(core_window_t* wd, const paint::image& img)
 		{
 			if(false == img.empty())
@@ -413,6 +421,19 @@ namespace detail
 				{
 					if(wd->other.category == category::root_tag::value)
 						native_interface::window_icon(wd->root, img);
+				}
+			}
+		}
+
+		void window_manager::icon(core_window_t* wd, const paint::image& big_icon, const paint::image& small_icon)
+		{
+			if(!big_icon.empty() || !small_icon.empty())
+			{
+				std::lock_guard<decltype(mutex_)> lock(mutex_);
+				if (impl_->wd_register.available(wd))
+				{
+					if(wd->other.category == category::root_tag::value)
+						native_interface::window_icon(wd->root, big_icon, small_icon);
 				}
 			}
 		}

--- a/source/gui/filebox.cpp
+++ b/source/gui/filebox.cpp
@@ -1021,6 +1021,7 @@ namespace nana
 			
 			if (!impl_->open_or_save)
 				ofn.Flags = OFN_OVERWRITEPROMPT;	//Overwrite prompt if it is save mode
+			ofn.Flags |= OFN_NOCHANGEDIR;
 			
 			if(FALSE == (impl_->open_or_save ? ::GetOpenFileName(&ofn) : ::GetSaveFileName(&ofn)))
 				return false;

--- a/source/gui/programming_interface.cpp
+++ b/source/gui/programming_interface.cpp
@@ -359,9 +359,19 @@ namespace API
 		restrict::window_manager.default_icon(img);
 	}
 
+	void window_icon_default(const paint::image& big_icon, const paint::image& small_icon)
+	{
+		restrict::window_manager.default_icon(big_icon, small_icon);
+	}
+
 	void window_icon(window wd, const paint::image& img)
 	{
 		restrict::window_manager.icon(reinterpret_cast<restrict::core_window_t*>(wd), img);
+	}
+
+	void window_icon(window wd, const paint::image& big_icon, const paint::image& small_icon)
+	{
+		restrict::window_manager.icon(reinterpret_cast<restrict::core_window_t*>(wd), big_icon, small_icon);
 	}
 
 	bool empty_window(window wd)

--- a/source/gui/widgets/combox.cpp
+++ b/source/gui/widgets/combox.cpp
@@ -685,7 +685,7 @@ namespace nana
 						{
 						case keyboard::os_arrow_left:
 						case keyboard::os_arrow_right:
-							drawer_->editor()->respond_key(arg.key);
+							drawer_->editor()->respond_key(arg);
 							drawer_->editor()->reset_caret();
 							break;
 						case keyboard::os_arrow_up:
@@ -714,14 +714,14 @@ namespace nana
 						}
 					}
 					if (call_other_keys)
-						drawer_->editor()->respond_key(arg.key);
+						drawer_->editor()->respond_key(arg);
 
 					API::lazy_refresh();
 				}
 
 				void trigger::key_char(graph_reference graph, const arg_keyboard& arg)
 				{
-					if (drawer_->editor()->respond_char(arg.key))
+					if (drawer_->editor()->respond_char(arg))
 						API::lazy_refresh();
 				}
 			//end class trigger

--- a/source/gui/widgets/label.cpp
+++ b/source/gui/widgets/label.cpp
@@ -628,6 +628,8 @@ namespace nana
 					nana::string target;	//It indicates which target is tracing.
 					nana::string url;
 
+					widget * buddy {nullptr};
+
 					void add_listener(std::function<void(command, const nana::string&)>&& fn)
 					{
 						listener_.emplace_back(std::move(fn));
@@ -740,6 +742,10 @@ namespace nana
 						impl_->call_listener(command::click, impl_->target);
 
 					system::open_url(url);
+
+					if (impl_->buddy) {
+						impl_->buddy->focus();
+					}
 				}
 
 				void trigger::refresh(graph_reference graph)
@@ -819,6 +825,11 @@ namespace nana
 		{
 			get_drawer_trigger().impl()->add_listener(std::move(f));
 			return *this;
+		}
+
+		void label::relate(widget& w)
+		{
+			get_drawer_trigger().impl()->buddy = &w;
 		}
 
 		nana::size label::measure(unsigned limited) const

--- a/source/gui/widgets/skeletons/text_editor.cpp
+++ b/source/gui/widgets/skeletons/text_editor.cpp
@@ -1629,7 +1629,10 @@ namespace nana{	namespace widgets
 					select_.mode_selection = selection::mode_mouse_selected;
 				}
 				else
+				{
+					select(false);
 					select_.mode_selection = selection::mode_no_selected;
+				}
 			}
 
 			text_area_.border_renderer(graph_, _m_bgcolor());

--- a/source/gui/widgets/skeletons/text_editor.cpp
+++ b/source/gui/widgets/skeletons/text_editor.cpp
@@ -2954,6 +2954,7 @@ namespace nana{	namespace widgets
 			if (if_mask && mask_char_)
 				mask_str.reset(new nana::string(str.size(), mask_char_));
 
+			bool focused = API::is_focus_ready(window_); // do this many times is not efficient...
 
 			auto & linestr = (if_mask && mask_char_ ? *mask_str : str);
 
@@ -2976,7 +2977,7 @@ namespace nana{	namespace widgets
 			graph_.set_color(scheme_->selection.get_color());
 
 			//The text is not selected or the whole line text is selected
-			if ((!_m_get_sort_select_points(a, b)) || (select_.a.y != str_pos.y && select_.b.y != str_pos.y))
+			if (!focused || (!_m_get_sort_select_points(a, b)) || (select_.a.y != str_pos.y && select_.b.y != str_pos.y))
 			{
 				bool selected = (a.y < str_pos.y && str_pos.y < b.y);
 				for (auto & ent : reordered)
@@ -2986,7 +2987,7 @@ namespace nana{	namespace widgets
 
 					if ((text_pos.x + static_cast<int>(str_w) > text_area_.area.x) && (text_pos.x < xend))
 					{
-						if (selected)
+						if (selected && focused)
 						{
 							graph_.set_text_color(scheme_->selection_text.get_color());
 							graph_.rectangle({ text_pos, { str_w, line_h_pixels } }, true);

--- a/source/gui/widgets/skeletons/text_editor.cpp
+++ b/source/gui/widgets/skeletons/text_editor.cpp
@@ -1619,20 +1619,12 @@ namespace nana{	namespace widgets
 
 				//Set caret pos by screen point and get the caret pos.
 				auto pos = mouse_caret(scrpos);
-				if(!hit_select_area(pos))
+				if(!select(false))
 				{
-					if(!select(false))
-					{
-						select_.a = points_.caret;	//Set begin caret
-						set_end_caret();
-					}
-					select_.mode_selection = selection::mode_mouse_selected;
+					select_.a = points_.caret;	//Set begin caret
+					set_end_caret();
 				}
-				else
-				{
-					select(false);
-					select_.mode_selection = selection::mode_no_selected;
-				}
+				select_.mode_selection = selection::mode_mouse_selected;
 			}
 
 			text_area_.border_renderer(graph_, _m_bgcolor());
@@ -2345,31 +2337,18 @@ namespace nana{	namespace widgets
 					case keyboard::os_arrow_up:
 					case keyboard::os_home:
 					case keyboard::os_pageup:
-						if (points_.caret == select_.b) {
-							select_.b = select_.a;
-						}else {
-							select_.b = std::max(select_.b, points_.caret);
-						}
-						select_.a = caret;
+						select_.b = caret;
 						break;
 					case keyboard::os_arrow_right:
 					case keyboard::os_arrow_down:
 					case keyboard::os_end:
 					case keyboard::os_pagedown:
-						if (select_.b == points_.caret) {
-							select_.a = std::min(select_.a, points_.caret);
-						}else {
-							select_.a = std::max(select_.b, points_.caret);
-						}
 						select_.b = caret;
 						break;
 					}
 				}else {
 					select_.b = caret;
 					select_.a = caret;
-				}
-				if (select_.a > select_.b) {
-					std::swap(select_.a, select_.b);
 				}
 				points_.caret = caret;
 				behavior_->adjust_caret_into_screen();

--- a/source/gui/widgets/spinbox.cpp
+++ b/source/gui/widgets/spinbox.cpp
@@ -560,7 +560,7 @@ namespace nana
 			
 			void drawer::key_press(graph_reference, const arg_keyboard& arg)
 			{
-				if (impl_->editor()->respond_key(arg.key))
+				if (impl_->editor()->respond_key(arg))
 				{
 					impl_->editor()->reset_caret();
 					impl_->draw_spins();
@@ -570,7 +570,7 @@ namespace nana
 
 			void drawer::key_char(graph_reference, const arg_keyboard& arg)
 			{
-				if (impl_->editor()->respond_char(arg.key))
+				if (impl_->editor()->respond_char(arg))
 				{
 					if (!impl_->value(impl_->editor()->text()))
 						impl_->draw_spins();

--- a/source/gui/widgets/textbox.cpp
+++ b/source/gui/widgets/textbox.cpp
@@ -89,7 +89,10 @@ namespace drawerbase {
 		void drawer::focus(graph_reference graph, const arg_focus& arg)
 		{
 			refresh(graph);
-
+			if (arg.getting) {
+				editor_->select(true);
+				editor_->move_caret_end();
+			}
 			editor_->show_caret(arg.getting);
 			editor_->reset_caret();
 			API::lazy_refresh();

--- a/source/gui/widgets/textbox.cpp
+++ b/source/gui/widgets/textbox.cpp
@@ -136,7 +136,7 @@ namespace drawerbase {
 
 		void drawer::key_press(graph_reference, const arg_keyboard& arg)
 		{
-			if(editor_->respond_key(arg.key))
+			if(editor_->respond_key(arg))
 			{
 				editor_->reset_caret();
 				API::lazy_refresh();
@@ -145,7 +145,7 @@ namespace drawerbase {
 
 		void drawer::key_char(graph_reference, const arg_keyboard& arg)
 		{
-			if (editor_->respond_char(arg.key))
+			if (editor_->respond_char(arg))
 				API::lazy_refresh();
 		}
 

--- a/source/gui/widgets/textbox.cpp
+++ b/source/gui/widgets/textbox.cpp
@@ -15,6 +15,9 @@
 #include <stdexcept>
 #include <sstream>
 
+#include <nana/gui/detail/bedrock.hpp>
+#include <nana/gui/detail/inner_fwd_implement.hpp>
+
 namespace nana
 {
 	arg_textbox::arg_textbox(textbox& wdg)
@@ -90,8 +93,13 @@ namespace drawerbase {
 		{
 			refresh(graph);
 			if (arg.getting) {
-				editor_->select(true);
-				editor_->move_caret_end();
+				static auto& brock = detail::bedrock::instance();
+				auto native_window = reinterpret_cast<native_window_type>(arg.receiver);
+				auto* root_runtime = brock.wd_manager.root_runtime(native_window);
+				if (root_runtime && root_runtime->condition.tabstop_focus_changed) {
+					editor_->select(true);
+					editor_->move_caret_end();
+				}
 			}
 			editor_->show_caret(arg.getting);
 			editor_->reset_caret();

--- a/source/gui/widgets/textbox.cpp
+++ b/source/gui/widgets/textbox.cpp
@@ -92,11 +92,13 @@ namespace drawerbase {
 		void drawer::focus(graph_reference graph, const arg_focus& arg)
 		{
 			refresh(graph);
-			if (arg.getting) {
+			if (!editor_->attr().multi_lines && arg.getting)
+			{
 				static auto& brock = detail::bedrock::instance();
 				auto native_window = reinterpret_cast<native_window_type>(arg.receiver);
 				auto* root_runtime = brock.wd_manager.root_runtime(native_window);
-				if (root_runtime && root_runtime->condition.tabstop_focus_changed) {
+				if (root_runtime && root_runtime->condition.tabstop_focus_changed)
+				{
 					editor_->select(true);
 					editor_->move_caret_end();
 				}

--- a/source/paint/graphics.cpp
+++ b/source/paint/graphics.cpp
@@ -812,7 +812,7 @@ namespace paint
 			size_.width = size_.height = 0;
 		}
 
-		void graphics::save_as_file(const char* file)
+		void graphics::save_as_file(const char* file) const
 		{
 			if(handle_)
 			{

--- a/source/paint/image.cpp
+++ b/source/paint/image.cpp
@@ -69,6 +69,31 @@ namespace paint
 				return false;
 			}
 
+			bool image_ico::open(void* buff, size_t sz)
+			{
+				close();
+#if defined(NANA_WINDOWS)
+				HICON handle = CreateIconFromResource((PBYTE)buff, sz, TRUE, 0x00030000);
+				if(handle)
+				{
+					ICONINFO info;
+					if (::GetIconInfo(handle, &info) != 0)
+					{
+						HICON * p = new HICON(handle);
+						ptr_ = std::shared_ptr<HICON>(p, handle_deleter());
+						size_.width = (info.xHotspot << 1);
+						size_.height = (info.yHotspot << 1);
+						::DeleteObject(info.hbmColor);
+						::DeleteObject(info.hbmMask);
+						return true;
+					}
+				}
+#else
+				if(is_ico_){}	//kill the unused compiler warning in Linux.
+#endif
+				return false;
+			}
+
 			bool image_ico::alpha_channel() const
 			{
 				return false;
@@ -233,6 +258,13 @@ namespace paint
 				}
 			}
 			return false;
+		}
+
+		bool image::open_icon(void* buff, size_t sz)
+		{
+			image::image_impl_interface * helper = new detail::image_ico(true);
+			image_ptr_ = std::shared_ptr<image_impl_interface>(helper);
+			return helper->open(buff, sz);
 		}
 
 		bool image::empty() const


### PR DESCRIPTION
Hi, I've added several features to nana library.
- added OFN_NOCHANGEDIR flag to OPENFILENAME::Flags in nana::filebox::show
- Big & Small icon support for Windows.
  - On Windows, the system displays the large icon in the ALT+TAB dialog box, and the small icon in the window caption.
- Open icon image from memory feature.
  - nana::paint::image::open_icon method seems a bit too concrete.
  - I've added this feature to set icon image from memory that is retrieved from resource data within executable file.
- Label::relate method.
  - It works like HTML label element **for** attribute.
  - By clicking a label, specified widget will be focused.
- Textbox selection handling improvements.
  - Select textbox content after tabstop event.
  - When textbox is not focused, its selection is not drawn to make it look quiet.
  - Improved cursor move keys handling.
  - Word selection support is still missing though.
