### PR TITLE
progressbar with stop()

### DIFF
--- a/include/nana/gui/widgets/progress.hpp
+++ b/include/nana/gui/widgets/progress.hpp
@@ -30,6 +30,8 @@ namespace nana
 				unsigned Max(unsigned);
 				void unknown(bool);
 				bool unknown() const;
+				bool stop(bool s = true);
+				bool stoped() const;
 			private:
 				void attached(widget_reference, graph_reference)	override;
 				void refresh(graph_reference)	override;
@@ -45,6 +47,7 @@ namespace nana
 				nana::paint::graphics* graph_{nullptr};
 				unsigned draw_width_{static_cast<unsigned>(-1)};
 				bool unknown_{false};
+				bool stop_{false};
 				unsigned max_{100};
 				unsigned value_{0};
 			}; //end class drawer
@@ -67,6 +70,8 @@ namespace nana
 		unsigned amount(unsigned value);
 		void unknown(bool);
 		bool unknown() const;
+		bool stop(bool s=true);  ///< request stop or cancel and return previus stop status
+		bool stoped() const;  
 	};
 }//end namespace nana
 #endif

--- a/source/gui/widgets/progress.cpp
+++ b/source/gui/widgets/progress.cpp
@@ -89,6 +89,15 @@ namespace nana
 			{
 				return unknown_;
 			}
+			bool trigger::stoped() const
+			{
+				return stop_;
+			}
+			bool trigger::stop(bool s)
+			{
+				std::swap(s,stop_);
+				return s;
+			}
 
 			void trigger::refresh(graph_reference)
 			{
@@ -196,6 +205,14 @@ namespace nana
 		bool progress::unknown() const
 		{
 			return get_drawer_trigger().unknown();
+		}
+		bool progress::stop(bool s)  
+		{
+			return get_drawer_trigger().stop(s);
+		}
+		bool progress::stoped() const
+		{
+			return get_drawer_trigger().stoped();
 		}
 	//end class progress
 }//end namespace nana


### PR DESCRIPTION
I was working with FreeMe and I realized that a common situation of stopping an action for with we use a progressbar is to communicate that state using self the progressbar.
It can be more sophisticate, but now is working. See the FreeMe (search for "stop" there):
 https://github.com/qPCR4vir/nana-demo/blob/file_explorer/FreeMe.cpp

Maybe we could throw in inc() if the progress is stopped? 