### PR TITLE
Fix: Workaround label constructor selecting bool instead nana::string…

### DIFF
--- a/include/nana/gui/widgets/label.hpp
+++ b/include/nana/gui/widgets/label.hpp
@@ -58,6 +58,7 @@ namespace nana
 		label();
 		label(window, bool visible);
 		label(window, const nana::string& text, bool visible = true);
+		label(window parent, const nana::char_t* text, bool visible = true) :label(parent, nana::string(text),visible) {};
 		label(window, const rectangle& = {}, bool visible = true);
 		label& transparent(bool);		///< Switchs the label widget to the transparent background mode.
 		bool transparent() const throw();

--- a/source/gui/widgets/picture.cpp
+++ b/source/gui/widgets/picture.cpp
@@ -143,7 +143,8 @@ namespace nana
 
 						_m_draw_background(valid_area.width, valid_area.height);
 
-						backimg.image.paste(valid_area, graph, pos);
+						if ( ! backimg.image.empty())
+							backimg.image.paste(valid_area, graph, pos);
 					}
 				}
 				else
@@ -163,7 +164,7 @@ namespace nana
 
 				if (graph && (bground_mode::basic != API::effects_bground_mode(*impl_->wdg_ptr)))
 				{
-					if (w < graph->size().width || h < graph->size().width || impl_->backimg.image.alpha())
+					if (w < graph->size().width || h < graph->size().height /*  .width   ???  */ || impl_->backimg.image.alpha())
 					{
 						auto & bground = impl_->gradual_bground;
 						if (bground.gradual_from.invisible() || bground.gradual_to.invisible())


### PR DESCRIPTION
… when called with nana::char_t* which silently brake a lot of code

Maybe there are more elegant solutions... The second constructor was eliminated in:

Commit: f4924ef2f8600fafa82d3fc0d1c4d5f9eea0c738 [f4924ef]
Parents: e0ee42d184
Author: Jinhao <cnjinhao@hotmail.com>
Date: Sonntag, 2. August 2015 19:37:36
Labels: develop
add throw() for some functions