### PR TITLE
small fix for gcc/mingw

### DIFF
--- a/source/filesystem/filesystem.cpp
+++ b/source/filesystem/filesystem.cpp
@@ -430,7 +430,8 @@ namespace nana {
 						delete[] p;
 						return s;
 					}
-					return buf;
+					nana::string s = buf;
+					return s;
 				}
 #elif defined(NANA_LINUX)
 				const char * s = ::getenv("PWD");


### PR DESCRIPTION
a small fix for the mingw users of us

another solution is to just write

    return static_cast<nana::string>(buf);

i'm not sure which one is better, so i stayed with the one 3 lines above