### PR TITLE
Fix listbox for auto_draw+inline_factory+item_proxy::value.

### DIFF
--- a/include/nana/gui/widgets/listbox.hpp
+++ b/include/nana/gui/widgets/listbox.hpp
@@ -368,6 +368,9 @@ namespace nana
 					item_proxy iter{ ess_, index_pair(pos_, size() - 1) };
 					if (set_value)
 						iter.value(std::forward<T>(t));
+
+					update();
+
 					return iter;
 				}
 
@@ -441,6 +444,7 @@ namespace nana
 				essence_t*	ess_{nullptr};
 				category_t*	cat_{nullptr};
 				size_type	pos_{0};  ///< Absolute position, not relative to display, and dont change during sort()
+				void update();
 			};
 		
 			struct export_options

--- a/source/gui/widgets/listbox.cpp
+++ b/source/gui/widgets/listbox.cpp
@@ -4188,7 +4188,6 @@ namespace nana
 						auto & m = cat_->items.back();
 						m.bgcolor = wd->bgcolor();
 						m.fgcolor = wd->fgcolor();
-						ess_->update();
 					}
 				}
 
@@ -4204,6 +4203,11 @@ namespace nana
 					auto i = ess_->lister.get(pos_);
 					cat_ = &(*i);
 				}
+
+				void cat_proxy::update() {
+					ess_->update();
+				}
+
 			//class cat_proxy
 
 			//end class cat_proxy


### PR DESCRIPTION
When calling templated append() overload on a shown listbox, auto_draw
caused an early redraw, which issued the inline widget set() member
function before the value() and value_ptr() were actually set.