### PR TITLE
Fix for mingw users (incomplete)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 
 #https://cmake.org/cmake-tutorial/
 #https://cmake.org/cmake/help/v3.3/module/CMakeDependentOption.html?highlight=cmakedependentoption
-# use CACHE FORCE  or set(USE_meganz_mingw_std_threads ON) or delete CMakecache.txt or the entirely build dir
+# use CACHEÂ FORCE  or set(USE_meganz_mingw_std_threads ON) or delete CMakecache.txt or the entirely build dir
 # if your changes don't execute
 option(USE_meganz_mingw_std_threads "replaced boost.thread with meganz's mingw-std-threads." OFF)
 option(USE_UNICODE "Use Unicode Character Set" ON)
@@ -143,8 +143,8 @@ aux_source_directory(${NANA_SOURCE_DIR}/paint/detail NANA_PAINT_DETAIL_SOURCE)
 aux_source_directory(${NANA_SOURCE_DIR}/system NANA_SYSTEM_SOURCE)
 aux_source_directory(${NANA_SOURCE_DIR}/threads NANA_THREADS_SOURCE)
 
-#To show .h files in Visual Studio, add them to the list of sources in add_executable / add_library
-#and Use SOURCE_GROUP if all your sources are in the same directory
+#ToÂ showÂ .hÂ filesÂ inÂ VisualÂ Studio,Â addÂ themÂ toÂ theÂ listÂ ofÂ sourcesÂ inÂ add_executableÂ /Â add_library
+#and UseÂ SOURCE_GROUPÂ ifÂ allÂ yourÂ sourcesÂ areÂ inÂ theÂ sameÂ directory
 
 add_library(${PROJECT_NAME} ${NANA_SOURCE}
                             ${NANA_DETAIL_SOURCE}
@@ -163,8 +163,8 @@ endif (NOT APPLE)
                             ${NANA_THREADS_SOURCE})       
 
 if(APPLE)
-    #Headers: use INCLUDE_DIRECTORIES
-    #   Libraries: use FIND_LIBRARY and link with the result of it (try to avoid LINK_DIRECTORIES
+    #Headers:Â useÂ INCLUDE_DIRECTORIES
+    #   Libraries:Â useÂ FIND_LIBRARYÂ andÂ linkÂ withÂ theÂ resultÂ ofÂ itÂ (tryÂ toÂ avoidÂ LINK_DIRECTORIES
     target_link_libraries(${PROJECT_NAME} -L/opt/X11/lib/ -lX11 -lXft -lpng -liconv)
 
 endif(APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,13 +146,12 @@ aux_source_directory(${NANA_SOURCE_DIR}/threads NANA_THREADS_SOURCE)
 #To show .h files in Visual Studio, add them to the list of sources in add_executable / add_library
 #and Use SOURCE_GROUP if all your sources are in the same directory
 
+if(NOT APPLE)
 add_library(${PROJECT_NAME} ${NANA_SOURCE}
                             ${NANA_DETAIL_SOURCE}
                             ${NANA_FILESYSTEM_SOURCE}
-if(NOT APPLE)
                             ${NANA_AUDIO_SOURCE}
                             ${NANA_AUDIO_DETAIL_SOURCE}
-endif (NOT APPLE)
                             ${NANA_GUI_SOURCE}
                             ${NANA_GUI_DETAIL_SOURCE}
                             ${NANA_GUI_WIDGETS_SOURCE}
@@ -160,9 +159,24 @@ endif (NOT APPLE)
                             ${NANA_PAINT_SOURCE}
                             ${NANA_PAINT_DETAIL_SOURCE}
                             ${NANA_SYSTEM_SOURCE}
-                            ${NANA_THREADS_SOURCE})       
+                            ${NANA_THREADS_SOURCE})    
+endif (NOT APPLE)   
+                            
 
 if(APPLE)
+add_library(${PROJECT_NAME} ${NANA_SOURCE}
+                            ${NANA_DETAIL_SOURCE}
+                            ${NANA_FILESYSTEM_SOURCE}
+                            ${NANA_AUDIO_SOURCE}
+                            ${NANA_AUDIO_DETAIL_SOURCE}
+                            ${NANA_GUI_SOURCE}
+                            ${NANA_GUI_DETAIL_SOURCE}
+                            ${NANA_GUI_WIDGETS_SOURCE}
+                            ${NANA_GUI_WIDGETS_SKELETONS_SOURCE}
+                            ${NANA_PAINT_SOURCE}
+                            ${NANA_PAINT_DETAIL_SOURCE}
+                            ${NANA_SYSTEM_SOURCE}
+                            ${NANA_THREADS_SOURCE})    
     #Headers: use INCLUDE_DIRECTORIES
     #   Libraries: use FIND_LIBRARY and link with the result of it (try to avoid LINK_DIRECTORIES
     target_link_libraries(${PROJECT_NAME} -L/opt/X11/lib/ -lX11 -lXft -lpng -liconv)

--- a/source/charset.cpp
+++ b/source/charset.cpp
@@ -18,6 +18,7 @@
 #include <nana/deploy.hpp>
 #include <cwchar>
 #include <clocale>
+#include <cstring>
 
 //GCC 4.7.0 does not implement the <codecvt> and codecvt_utfx classes
 #ifndef STD_CODECVT_NOT_SUPPORTED


### PR DESCRIPTION
here are three little fixes for the current 1.3 alpha release.

hope the commits are self-explanatory. if not pls give me ring.

1. Changed CMakeLists.txt encoding to utf-8 (i simply suppose thats how it should be)
2. CMake 3.3.0 told me there was a problem with 'if' --> see the change 
3. seems like in Microsofts STL already includes ```<cstring>``` at some point, but with libstdc++ it was required to include it explicitly

there is another issue i could not fix:
using Microsofts STL it is possible to open a std::basic_ifstream<char> with an wchar_t* path (even though it's not standard behaviour)

```
Error:

In file included from D:\nana\source\paint\image.cpp:31:0:
D:\nana\source\paint\detail/image_bmp.hpp: In member function 'virtual bool nana::paint::detail::image_bmp::open(const nana::experimental::filesystem::path&)':
D:\nana\source\paint\detail/image_bmp.hpp:88:57: error: no matching function for call to 'std::basic_ifstream<char>::basic_ifstream(const value_type*, const openmode&)'
     std::ifstream ifs(filename.c_str(), std::ios::binary);
```

nana makes use of this non-standard-feature in the image_bmp.hpp.

Used compilers:
MSVC2015 --> working
MinGW gcc-5.1.0-tdm64-1-c++ --> errors as described

best regards,
Jan