### PR TITLE
Automatic GUI test pass in travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ build/makefile-bkl/*
 *.ilk
 *.log
 [Bb]in
+[Bb]in/
 [Dd]ebug*/
 *.lib
 *.a

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,9 @@ install:
   - /tmp/tools/cmake --prefix="$HOME" --exclude-subdir
 
 before_script :
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start
   - mkdir bld
   - cd bld
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -128,7 +128,7 @@ script:
   #- ./screen  
   - ./stretch_image  
   - ./threading  
-  - ./thread-pool  
+  #- ./thread-pool  
   - ./various_events  
   #- ./window-dragger
   - ./windows-subclassing   

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ matrix:
             - llvm-toolchain-precise 
 
 before_install:
-  - git clone --depth=50 --branch=testing https://github.com/qPCR4vir/nana-demo.git nana-demo
+  - git clone --depth=1 --branch=dev_nana_in_examples https://github.com/qPCR4vir/nana-demo.git nana-demo
   - export PATH="$HOME/bin:$PATH"
   - mkdir ~/bin
   - wget --no-check-certificate --no-clobber -O /tmp/tools/cmake https://cmake.org/files/v3.4/cmake-3.4.0-rc3-Linux-x86_64.sh || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -127,10 +127,10 @@ script:
   - ./png  
   #- ./screen  
   - ./stretch_image  
-  #- ./threading  # Press a char: 
+  - ./threading  
   - ./thread-pool  
   - ./various_events  
-  - ./window-dragger
+  #- ./window-dragger
   - ./windows-subclassing   
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,4 +76,25 @@ script:
   - cmake -G"Unix Makefiles" .. -DNANA_CMAKE_ENABLE_JPEG=ON -DNANA_CMAKE_ENABLE_PNG=OFF -DNANA_CMAKE_BUILD_DEMOS=ON -DNANA_CMAKE_ENABLE_AUDIO=OFF -DNANA_CMAKE_FIND_BOOST_FILESYSTEM=ON -DNANA_CMAKE_INCLUDE_EXPERIMENTAL_DEMOS=OFF -DNANA_CMAKE_AUTOMATIC_GUI_TESTING=ON -DNANA_CMAKE_ADD_DEF_AUTOMATIC_GUI_TESTING=ON
   - make
   - ls
+  - ./clicked
+  - ./HelloWord
+  - ./background-effects
+  - ./categ
+  - ./decore
+  - ./dock
+  - ./drag-button
+  - ./draw
+  - ./file_explorer
+  #- ./example_menu
+  - ./example_listbox
+  #- ./example_combox
+  #- ./example.button
+  #- ./MontiHall
+  - ./a_group_impl
+  #- ./animate-bmp
+  #- ./calculator  
+  #- ./helloworld_demo 
+  #- ./notepad 
+  
+
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,23 +66,26 @@ install:
   - /tmp/tools/cmake --prefix="$HOME" --exclude-subdir
 
 before_script :
+  # travis dont have a fisical monitor. We need to instal an emulator: https://docs.travis-ci.com/user/gui-and-headless-browsers/
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
   - sleep 3 # give xvfb some time to start
-  - mkdir bld
-  - cd bld
+  # we have:  qPCR4vir/nana/nana-demo and  now we are in: qPCR4vir/nana/  our executable tests will assces: ../Examples/*.bmp etc.(need to be in parallel with nana-demo/Examples)
+  - cd nana-demo
+  - mkdir bin
+  - cd bin
 
 script:
-  - cmake -G"Unix Makefiles" .. -DNANA_CMAKE_ENABLE_JPEG=ON -DNANA_CMAKE_ENABLE_PNG=OFF -DNANA_CMAKE_BUILD_DEMOS=ON -DNANA_CMAKE_ENABLE_AUDIO=OFF -DNANA_CMAKE_FIND_BOOST_FILESYSTEM=ON -DNANA_CMAKE_INCLUDE_EXPERIMENTAL_DEMOS=OFF -DNANA_CMAKE_AUTOMATIC_GUI_TESTING=ON -DNANA_CMAKE_ADD_DEF_AUTOMATIC_GUI_TESTING=ON
+  - cmake -G"Unix Makefiles" ../.. -DNANA_CMAKE_ENABLE_JPEG=ON -DNANA_CMAKE_ENABLE_PNG=OFF -DNANA_CMAKE_BUILD_DEMOS=ON -DNANA_CMAKE_ENABLE_AUDIO=OFF -DNANA_CMAKE_FIND_BOOST_FILESYSTEM=ON -DNANA_CMAKE_INCLUDE_EXPERIMENTAL_DEMOS=OFF -DNANA_CMAKE_AUTOMATIC_GUI_TESTING=ON -DNANA_CMAKE_ADD_DEF_AUTOMATIC_GUI_TESTING=ON
   - make
   - ls
-  - ./audio_player
   - ./a_group_impl
-  #- ./animate-bmp
+  - ./animate-bmp
+  - ./audio_player
   - ./background-effects
+  #- ./calculator ?
   - ./categ
-  #- ./calculator
-  - ./clicked 
+  - ./clicked
   - ./decore
   - ./dock
   - ./drag-button
@@ -91,7 +94,7 @@ script:
   #- ./example_menu
   - ./example_listbox
   #- ./example_combox
-  #- ./example.button  # ??
+  - ./example.button
   - ./HelloWord
   #- ./MontiHall
   #- ./helloworld_demo 

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ script:
   - ./animate-bmp
   - ./audio_player
   - ./background-effects
-  #- ./calculator ?
+  - ./calculator 
   - ./categ
   - ./clicked
   - ./decore
@@ -94,18 +94,45 @@ script:
   - ./drag-button
   - ./draw
   - ./file_explorer
-  #- ./example_menu
+  - ./example_menu
   - ./example_listbox
-  #- ./example_combox
+  - ./example_combox
   - ./example.button
+  - ./folder_tree_nana
+  - ./folder_tree_std
+  - ./framework_design_1
+  - ./framework_design_2
+  - ./framework_design_3
+  - ./group
   - ./HelloWord
-  #- ./MontiHall
-  #- ./helloworld_demo 
-  #- ./notepad 
-  #- ./loader_2
-  #- ./widget_show2
-  #- ./widget_show
-  
-  
+  - ./helloword_quit
+  - ./inputbox  
+  - ./label_listener  
+  - ./lambda_event.cpp11  
+  - ./listbox_inline_widget  
+  - ./listbox_Resolver  
+  - ./loader_1  
+  - ./loader_2  
+  - ./mbox  
+  - ./menu_debug  
+  - ./MontiHall
+  - ./helloworld_demo 
+  - ./notepad 
+  - ./loader_2
+  - ./mbox  
+  - ./menu_debug  
+  - ./menu_popuper  
+  - ./modal_form   
+  - ./widget_show2
+  - ./widget_show
+  - ./place_login  
+  - ./png  
+  - ./screen  
+  - ./stretch_image  
+  - ./threading  
+  - ./thread-pool  
+  - ./various_events  
+  - ./window-dragger
+  - ./windows-subclassing   
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,12 +91,12 @@ script:
   #- ./example_menu
   - ./example_listbox
   #- ./example_combox
-  - ./example.button
+  #- ./example.button  # ??
   - ./HelloWord
   #- ./MontiHall
   #- ./helloworld_demo 
   #- ./notepad 
-  - ./loader_2
+  #- ./loader_2
 
   
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ before_script :
   - cd bin
 
 script:
-  - cmake -G"Unix Makefiles" .. -DNANA_CMAKE_ENABLE_JPEG=ON -DNANA_CMAKE_ENABLE_PNG=OFF -DNANA_CMAKE_BUILD_DEMOS=ON -DNANA_CMAKE_ENABLE_AUDIO=OFF -DNANA_CMAKE_FIND_BOOST_FILESYSTEM=ON -DNANA_CMAKE_INCLUDE_EXPERIMENTAL_DEMOS=OFF -DNANA_CMAKE_AUTOMATIC_GUI_TESTING=ON -DNANA_CMAKE_ADD_DEF_AUTOMATIC_GUI_TESTING=ON
+  - cmake -G"Unix Makefiles" .. -DNANA_CMAKE_ENABLE_JPEG=ON -DNANA_CMAKE_ENABLE_PNG=OFF -DNANA_CMAKE_BUILD_DEMOS=ON -DNANA_CMAKE_ENABLE_AUDIO=OFF -DNANA_CMAKE_FIND_BOOST_FILESYSTEM=ON -DNANA_CMAKE_INCLUDE_EXPERIMENTAL_DEMOS=OFF -DNANA_CMAKE_AUTOMATIC_GUI_TESTING=ON
   - make
   - cd ..
   - mv -v bin/ nana-demo/
@@ -86,7 +86,7 @@ script:
   - ./animate-bmp
   - ./audio_player
   - ./background-effects
-  - ./calculator 
+  #- ./calculator 
   - ./categ
   - ./clicked
   - ./decore
@@ -94,18 +94,18 @@ script:
   - ./drag-button
   - ./draw
   - ./file_explorer
-  - ./example_menu
+  #- ./example_menu
   - ./example_listbox
-  - ./example_combox
+  #- ./example_combox
   - ./example.button
-  - ./folder_tree_nana
-  - ./folder_tree_std
+  #- ./folder_tree_nana
+  #- ./folder_tree_std
   - ./framework_design_1
   - ./framework_design_2
   - ./framework_design_3
   - ./group
   - ./HelloWord
-  - ./helloword_quit
+  #- ./helloword_quit
   - ./inputbox  
   - ./label_listener  
   - ./lambda_event.cpp11  

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,25 +76,28 @@ script:
   - cmake -G"Unix Makefiles" .. -DNANA_CMAKE_ENABLE_JPEG=ON -DNANA_CMAKE_ENABLE_PNG=OFF -DNANA_CMAKE_BUILD_DEMOS=ON -DNANA_CMAKE_ENABLE_AUDIO=OFF -DNANA_CMAKE_FIND_BOOST_FILESYSTEM=ON -DNANA_CMAKE_INCLUDE_EXPERIMENTAL_DEMOS=OFF -DNANA_CMAKE_AUTOMATIC_GUI_TESTING=ON -DNANA_CMAKE_ADD_DEF_AUTOMATIC_GUI_TESTING=ON
   - make
   - ls
-  - ./clicked
-  - ./HelloWord
+  - ./audio_player
+  - ./a_group_impl
+  - ./animate-bmp
   - ./background-effects
   - ./categ
+  - ./calculator
+  - ./clicked 
   - ./decore
   - ./dock
   - ./drag-button
   - ./draw
   - ./file_explorer
-  #- ./example_menu
+  - ./example_menu
   - ./example_listbox
-  #- ./example_combox
-  #- ./example.button
-  #- ./MontiHall
-  - ./a_group_impl
-  #- ./animate-bmp
-  #- ./calculator  
-  #- ./helloworld_demo 
-  #- ./notepad 
+  - ./example_combox
+  - ./example.button
+  - ./HelloWord
+  - ./MontiHall
+  - ./helloworld_demo 
+  - ./notepad 
+
+  
   
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,13 +71,16 @@ before_script :
   - "sh -e /etc/init.d/xvfb start"
   - sleep 3 # give xvfb some time to start
   # we have:  qPCR4vir/nana/nana-demo and  now we are in: qPCR4vir/nana/  our executable tests will assces: ../Examples/*.bmp etc.(need to be in parallel with nana-demo/Examples)
-  - cd nana-demo
+  #- cd nana-demo
   - mkdir bin
   - cd bin
 
 script:
-  - cmake -G"Unix Makefiles" ../.. -DNANA_CMAKE_ENABLE_JPEG=ON -DNANA_CMAKE_ENABLE_PNG=OFF -DNANA_CMAKE_BUILD_DEMOS=ON -DNANA_CMAKE_ENABLE_AUDIO=OFF -DNANA_CMAKE_FIND_BOOST_FILESYSTEM=ON -DNANA_CMAKE_INCLUDE_EXPERIMENTAL_DEMOS=OFF -DNANA_CMAKE_AUTOMATIC_GUI_TESTING=ON -DNANA_CMAKE_ADD_DEF_AUTOMATIC_GUI_TESTING=ON
+  - cmake -G"Unix Makefiles" .. -DNANA_CMAKE_ENABLE_JPEG=ON -DNANA_CMAKE_ENABLE_PNG=OFF -DNANA_CMAKE_BUILD_DEMOS=ON -DNANA_CMAKE_ENABLE_AUDIO=OFF -DNANA_CMAKE_FIND_BOOST_FILESYSTEM=ON -DNANA_CMAKE_INCLUDE_EXPERIMENTAL_DEMOS=OFF -DNANA_CMAKE_AUTOMATIC_GUI_TESTING=ON -DNANA_CMAKE_ADD_DEF_AUTOMATIC_GUI_TESTING=ON
   - make
+  - cd ..
+  - mv -v bin/ nana-demo/
+  - cd nana-demo/bin
   - ls
   - ./a_group_impl
   - ./animate-bmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,7 +98,7 @@ script:
   #- ./notepad 
   #- ./loader_2
   #- ./widget_show2
-
+  #- ./widget_show
   
   
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -112,22 +112,22 @@ script:
   - ./listbox_inline_widget  
   - ./listbox_Resolver  
   - ./loader_1  
-  - ./loader_2  
+  #- ./loader_2  
   - ./mbox  
   - ./menu_debug  
-  - ./MontiHall
-  - ./helloworld_demo 
-  - ./notepad 
+  #- ./MontiHall
+  #- ./helloworld_demo 
+  #- ./notepad 
   - ./menu_debug  
   - ./menu_popuper  
-  - ./modal_form   
-  - ./widget_show2
-  - ./widget_show
+  #- ./modal_form   
+  #- ./widget_show2
+  #- ./widget_show
   - ./place_login  
   - ./png  
-  - ./screen  
+  #- ./screen  
   - ./stretch_image  
-  - ./threading  
+  #- ./threading  # Press a char: 
   - ./thread-pool  
   - ./various_events  
   - ./window-dragger

--- a/.travis.yml
+++ b/.travis.yml
@@ -106,9 +106,9 @@ script:
   - ./group
   - ./HelloWord
   #- ./helloword_quit
-  - ./inputbox  
+  #- ./inputbox  
   - ./label_listener  
-  - ./lambda_event.cpp11  
+  #- ./lambda_event.cpp11  
   - ./listbox_inline_widget  
   - ./listbox_Resolver  
   - ./loader_1  
@@ -118,8 +118,6 @@ script:
   - ./MontiHall
   - ./helloworld_demo 
   - ./notepad 
-  - ./loader_2
-  - ./mbox  
   - ./menu_debug  
   - ./menu_popuper  
   - ./modal_form   

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,24 +78,25 @@ script:
   - ls
   - ./audio_player
   - ./a_group_impl
-  - ./animate-bmp
+  #- ./animate-bmp
   - ./background-effects
   - ./categ
-  - ./calculator
+  #- ./calculator
   - ./clicked 
   - ./decore
   - ./dock
   - ./drag-button
   - ./draw
   - ./file_explorer
-  - ./example_menu
+  #- ./example_menu
   - ./example_listbox
-  - ./example_combox
+  #- ./example_combox
   - ./example.button
   - ./HelloWord
-  - ./MontiHall
-  - ./helloworld_demo 
-  - ./notepad 
+  #- ./MontiHall
+  #- ./helloworld_demo 
+  #- ./notepad 
+  - ./loader_2
 
   
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,6 +97,7 @@ script:
   #- ./helloworld_demo 
   #- ./notepad 
   #- ./loader_2
+  #- ./widget_show2
 
   
   

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,6 @@ option(NANA_CMAKE_STOP_VERBOSE_PREPROCESSOR "Stop compilation after showing the 
 option(NANA_CMAKE_BUILD_DEMOS "Build all the demos form the nana_demo repository." OFF)
 option(NANA_CMAKE_INCLUDE_EXPERIMENTAL_DEMOS "" ON)
 option(NANA_CMAKE_AUTOMATIC_GUI_TESTING "Activate automatic GUI testing?" OFF)
-option(NANA_CMAKE_ADD_DEF_AUTOMATIC_GUI_TESTING "Add defoult automatic GUI test?" OFF)
 option(NANA_CMAKE_BUILD_FreeMe "Build FreeMe (currently broken)?" OFF)
 
 
@@ -177,10 +176,6 @@ if(NANA_CMAKE_ENABLE_AUDIO)
     endif(UNIX)
 endif(NANA_CMAKE_ENABLE_AUDIO)
 
-if (NANA_CMAKE_BUILD_FreeMe)
-    add_definitions(-DBUILD_FreeMe)
-endif (NANA_CMAKE_BUILD_FreeMe)
-
 if(NANA_CMAKE_VERBOSE_PREPROCESSOR)
     add_definitions(-DVERBOSE_PREPROCESSOR)
 endif(NANA_CMAKE_VERBOSE_PREPROCESSOR)
@@ -249,10 +244,6 @@ if (NANA_CMAKE_BUILD_DEMOS)
          enable_testing ()
 	endif(NANA_CMAKE_AUTOMATIC_GUI_TESTING)
 
-	if(NANA_CMAKE_ADD_DEF_AUTOMATIC_GUI_TESTING)
-	     add_definitions(-DNANA_ADD_DEF_AUTOMATIC_GUI_TESTING)
-	endif(NANA_CMAKE_ADD_DEF_AUTOMATIC_GUI_TESTING)
-	
     set (demos    calculator file_explorer helloworld_demo notepad        )
 
     foreach ( demo ${demos})
@@ -269,6 +260,10 @@ if (NANA_CMAKE_BUILD_DEMOS)
     endforeach( demo ${demos})
 
     set (demos    widget_show widget_show2      )
+
+if (NANA_CMAKE_BUILD_FreeMe)
+    add_definitions(-DBUILD_FreeMe)
+endif (NANA_CMAKE_BUILD_FreeMe)
 
     if (NANA_CMAKE_INCLUDE_EXPERIMENTAL_DEMOS)
         list(APPEND demos  FreeMe)    # ??

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,7 +271,7 @@ if (NANA_CMAKE_BUILD_DEMOS)
     set (demos    widget_show widget_show2      )
 
     if (NANA_CMAKE_INCLUDE_EXPERIMENTAL_DEMOS)
-        list(APPEND demos  file_explorer FreeMe)    # ??
+        list(APPEND demos  FreeMe)    # ??
     endif (NANA_CMAKE_INCLUDE_EXPERIMENTAL_DEMOS)
     # Pending:      FreeMe (added but really completelly compiled if defined BUILD_FreeMe  )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ option(NANA_CMAKE_BOOST_FILESYSTEM_FORCE "Force use of Boost filesystem if avail
 #option(NANA_CMAKE_BOOST_FILESYSTEM_INCLUDE_ROOT "Where to find <boost/filesystem.hpp>?" "../")
 #option(NANA_CMAKE_BOOST_FILESYSTEM_LIB "Flag for the compiler to link: " "-lboost/fs")
 #include_directories("${NANA_CMAKE_BOOST_FILESYSTEM_INCLUDE_ROOT}")
-#list(APPEND NANA_LINKS "${NANA_CMAKE_BOOST_FILESYSTEM_LIB}")
+#list(APPEND NANA_LINKS "${NANA_CMAKE_BOOST_FILESYSTEM_LIB}" )
 
 
 if (NANA_CMAKE_NANA_FILESYSTEM_FORCE)
@@ -181,18 +181,6 @@ if (NANA_CMAKE_BUILD_FreeMe)
     add_definitions(-DBUILD_FreeMe)
 endif (NANA_CMAKE_BUILD_FreeMe)
 
-
-if(NANA_CMAKE_AUTOMATIC_GUI_TESTING)
-    add_definitions(-DNANA_AUTOMATIC_GUI_TESTING)
-
-    if(NANA_CMAKE_ADD_DEF_AUTOMATIC_GUI_TESTING)
-        add_definitions(-DNANA_ADD_DEF_AUTOMATIC_GUI_TESTING)
-    endif(NANA_CMAKE_ADD_DEF_AUTOMATIC_GUI_TESTING)
-
-endif(NANA_CMAKE_AUTOMATIC_GUI_TESTING)
-
-
-
 if(NANA_CMAKE_VERBOSE_PREPROCESSOR)
     add_definitions(-DVERBOSE_PREPROCESSOR)
 endif(NANA_CMAKE_VERBOSE_PREPROCESSOR)
@@ -265,7 +253,7 @@ if (NANA_CMAKE_BUILD_DEMOS)
 	     add_definitions(-DNANA_ADD_DEF_AUTOMATIC_GUI_TESTING)
 	endif(NANA_CMAKE_ADD_DEF_AUTOMATIC_GUI_TESTING)
 	
-    set (demos     helloworld_demo notepad        )
+    set (demos    calculator file_explorer helloworld_demo notepad        )
 
     foreach ( demo ${demos})
         add_executable(${demo} "../nana-demo/${demo}.cpp")
@@ -274,16 +262,16 @@ if (NANA_CMAKE_BUILD_DEMOS)
         #if(NANA_CMAKE_AUTOMATIC_GUI_TESTING)
             #add_custom_command( TARGET  ${demo} POST_BUILD COMMAND  ${demo} )
             #add_custom_target(do_always_${demo} ALL COMMAND ${demo})
-            add_test(${demo} COMMAND ${demo})
+            #add_test(${demo} COMMAND ${demo})
         #endif(NANA_CMAKE_AUTOMATIC_GUI_TESTING)
         install(TARGETS ${demo} RUNTIME DESTINATION  "../nana-demo/")
         message("... to build: ../nana-demo/${demo}.cpp" )
     endforeach( demo ${demos})
 
-    set (demos     calculator  widget_show widget_show2      )
+    set (demos    widget_show widget_show2      )
 
     if (NANA_CMAKE_INCLUDE_EXPERIMENTAL_DEMOS)
-        list(APPEND demos  file_explorer FreeMe)
+        list(APPEND demos  file_explorer FreeMe)    # ??
     endif (NANA_CMAKE_INCLUDE_EXPERIMENTAL_DEMOS)
     # Pending:      FreeMe (added but really completelly compiled if defined BUILD_FreeMe  )
 
@@ -300,7 +288,7 @@ if (NANA_CMAKE_BUILD_DEMOS)
                   decore dock  drag-button  draw example.button example_combox example_listbox example_menu
                   filebox-txt folder_tree folder_tree_nana folder_tree_std framework_design_1 framework_design_2 framework_design_3
                   group HelloWord helloword_quit inputbox label_listener lambda_event.Cpp11 listbox_inline_widget listbox_Resolver loader_1 loader_2
-                  mbox menu_debug menu_popuper modal_form MontiHall place_login png screen stretch_image
+                  main mbox menu_debug menu_popuper modal_form MontiHall place_login png screen stretch_image
                   threading thread-pool various_events window-dragger windows-subclassing
                   )
     # Pending: 

--- a/include/nana/config.hpp
+++ b/include/nana/config.hpp
@@ -96,15 +96,11 @@
 
 ///////////////////
 //  Support for NANA_AUTOMATIC_GUI_TESTING
-//	  Will cause the program to self-test the GUI.
-//    If NANA_ADD_DEF_AUTOMATIC_GUI_TESTING is also defined a default automatic GUI test
+//	  Will cause the program to self-test the GUI. A default automatic GUI test 
 //    will be added to all programs which don't have yet one defined. This default test will simple
 //    wait 10 sec. (time to construct, show and execute the GUI) and then exit normally.
 //
-//#define NANA_AUTOMATIC_GUI_TESTING
-//#if defined(NANA_AUTOMATIC_GUI_TESTING)
-	//#define NANA_ADD_DEF_AUTOMATIC_GUI_TESTING
-//#endif
+#define NANA_AUTOMATIC_GUI_TESTING
 
 
 

--- a/include/nana/config.hpp
+++ b/include/nana/config.hpp
@@ -100,7 +100,7 @@
 //    will be added to all programs which don't have yet one defined. This default test will simple
 //    wait 10 sec. (time to construct, show and execute the GUI) and then exit normally.
 //
-#define NANA_AUTOMATIC_GUI_TESTING
+//#define NANA_AUTOMATIC_GUI_TESTING
 
 
 

--- a/include/nana/gui/detail/bedrock.hpp
+++ b/include/nana/gui/detail/bedrock.hpp
@@ -1,13 +1,15 @@
-/*
+/**
  *	A Bedrock Implementation
  *	Nana C++ Library(http://www.nanapro.org)
- *	Copyright(C) 2003-2015 Jinhao(cnjinhao@hotmail.com)
+ *	Copyright(C) 2003-2016 Jinhao(cnjinhao@hotmail.com)
  *
  *	Distributed under the Boost Software License, Version 1.0.
  *	(See accompanying file LICENSE_1_0.txt or copy at
  *	http://www.boost.org/LICENSE_1_0.txt)
  *
- *	@file: nana/gui/detail/bedrock.hpp
+ *	@file nana/gui/detail/bedrock.hpp
+ *
+ *  @brief A Bedrock Implementation
  */
 
 #ifndef NANA_GUI_DETAIL_BEDROCK_HPP
@@ -26,9 +28,8 @@ namespace detail
 	struct	basic_window;
 	class	window_manager;
 
-	//class bedrock
-	//@brief:	bedrock is a fundamental core component, it provides a abstract to the OS platform
-	//			and some basic functions.
+	
+	/// @brief	fundamental core component, it provides an abstraction to the OS platform and some basic functions.
 	class bedrock
 	{
 		bedrock();

--- a/include/nana/gui/programming_interface.hpp
+++ b/include/nana/gui/programming_interface.hpp
@@ -143,9 +143,17 @@ namespace API
 		};
 	}//end namespace detail
 
-	void exit();
+	void exit();	    ///< close all windows in current thread
+	void exit_all();	///< close all windows 
 
-	std::string transform_shortkey_text(std::string text, wchar_t &shortkey, std::string::size_type *skpos);
+	/// @brief	Searchs whether the text contains a '&' and removes the character for transforming.
+	///			If the text contains more than one '&' charachers, the others are ignored. e.g
+	///			text = "&&a&bcd&ef", the result should be "&abcdef", shortkey = 'b', and pos = 2.
+	std::string transform_shortkey_text
+					( std::string text,      ///< the text is transformed
+					  wchar_t &shortkey,     ///<  the character which indicates a short key.
+					  std::string::size_type *skpos ///< retrives the shortkey position if it is not a null_ptr;
+					);
 	bool register_shortkey(window, unsigned long);
 	void unregister_shortkey(window);
 

--- a/include/nana/gui/wvl.hpp
+++ b/include/nana/gui/wvl.hpp
@@ -1,20 +1,19 @@
-/*
+/**
  *	Nana GUI Library Definition
  *	Nana C++ Library(http://www.nanapro.org)
- *	Copyright(C) 2003-2015 Jinhao(cnjinhao@hotmail.com)
+ *	Copyright(C) 2003-2016 Jinhao(cnjinhao@hotmail.com)
  *
  *	Distributed under the Boost Software License, Version 1.0.
  *	(See accompanying file LICENSE_1_0.txt or copy at
  *	http://www.boost.org/LICENSE_1_0.txt)
  *
- *	@file: nana/gui/wvl.hpp
- *	@description:
+ *	@file nana/gui/wvl.hpp
+ *	@description
  *		the header file contains the files required for running of Nana.GUI
  */
 
 #ifndef NANA_GUI_WVL_HPP
 #define NANA_GUI_WVL_HPP
-
 
 
 #include "programming_interface.hpp"
@@ -60,7 +59,26 @@ namespace nana
     template<typename Form, bool IsVisible = true>
     using form_loader = detail::form_loader<Form, IsVisible>;
 
-	void exec(unsigned wait = 0, std::function<void()> = {}, unsigned wait_end=0, form *fm= nullptr);
+	/// @brief  Take control of the GUI and optionaly automaticaly tests it.
+	///
+	/// @detail It transfers to nana the program flow control, which begin pumping messages 
+	///         from the underlying OS, interpreting and sending it with suitable arguments 
+	///         to the nana widgets that registered a response in the corresponding event.	
+	///         It also accept arguments to be used in case of automatic GUI testing.	
+	///         Other Way the arguments are ignored. It seems that only works in simple 
+	///         programs with only one active form ??
+	void exec(form *main_form = nullptr, ///< used to close the program
+		      unsigned wait = 1,         ///< for the GUI to be constructed, in seconds  
+		      unsigned wait_end = 1,     ///< for the GUI to be destructed, in seconds
+		      std::function<void()> = {} ///< emit events to mimics user actions and may asert results
+	         );
+
+	/// send a click message to this widget - useffull in GUI testing
+	void click(widget& w);
+
+	/// in seconds
+	void Wait(unsigned wait = 0);
+
  
 }//end namespace nana
 #endif

--- a/include/nana/gui/wvl.hpp
+++ b/include/nana/gui/wvl.hpp
@@ -23,6 +23,7 @@
 #include "msgbox.hpp"
 #include "place.hpp"
 
+
 namespace nana
 {
 	namespace detail

--- a/include/nana/gui/wvl.hpp
+++ b/include/nana/gui/wvl.hpp
@@ -66,9 +66,8 @@ namespace nana
 	///         from the underlying OS, interpreting and sending it with suitable arguments 
 	///         to the nana widgets that registered a response in the corresponding event.	
 	///         It also accept arguments to be used in case of automatic GUI testing.	
-	///         Other Way the arguments are ignored. It seems that only works in simple 
-	///         programs with only one active form ??
-	void exec(form *main_form = nullptr, ///< used to close the program
+	///         Other Way the arguments are ignored. 
+	void exec(
 		      unsigned wait = 1,         ///< for the GUI to be constructed, in seconds  
 		      unsigned wait_end = 1,     ///< for the GUI to be destructed, in seconds
 		      std::function<void()> = {} ///< emit events to mimics user actions and may asert results

--- a/source/gui/detail/bedrock_windows.cpp
+++ b/source/gui/detail/bedrock_windows.cpp
@@ -1,4 +1,4 @@
-/*
+/**
  *	A Bedrock Implementation
  *	Nana C++ Library(http://www.nanapro.org)
  *	Copyright(C) 2003-2016 Jinhao(cnjinhao@hotmail.com)
@@ -7,7 +7,8 @@
  *	(See accompanying file LICENSE_1_0.txt or copy at
  *	http://www.boost.org/LICENSE_1_0.txt)
  *
- *	@file: nana/gui/detail/win32/bedrock.cpp
+ *	@file nana/gui/detail/win32/bedrock.cpp
+ *  @brief A Bedrock Implementation
  *	@contributors: Ariel Vina-Rodriguez
  */
 
@@ -18,6 +19,7 @@
 #include <nana/gui/detail/event_code.hpp>
 #include <nana/system/platform.hpp>
 #include <sstream>
+#include <iostream>
 #include <nana/system/timepiece.hpp>
 #include <nana/gui.hpp>
 #include <nana/gui/detail/inner_fwd_implement.hpp>
@@ -254,6 +256,7 @@ namespace detail
 		{
 			std::stringstream ss;
 			ss<<"Nana.GUI detects a memory leaks in window_manager, "<<static_cast<unsigned>(wd_manager().number_of_core_window())<<" window(s) are not uninstalled.";
+			std::cerr << ss.str();  /// \todo add list of cations of open windows and if aut testin GUI do auto Ok after 2 sec.
 			::MessageBoxA(0, ss.str().c_str(), ("Nana C++ Library"), MB_OK);
 		}
 
@@ -261,8 +264,8 @@ namespace detail
 		delete pi_data_;
 	}
 
-	//inc_window
-	//@brief: increament the number of windows
+
+	/// @brief increament the number of windows in the thread id
 	int bedrock::inc_window(unsigned tid)
 	{
 		//impl refers to the object of private_impl, the object is created when bedrock is creating.
@@ -461,6 +464,7 @@ namespace detail
 		{
 			(msgbox(modal_window, "An exception during message pumping!").icon(msgbox::icon_information)
 				<<"An uncaptured non-std exception during message pumping!"
+				<< "\n   in form: " << API::window_caption(modal_window)
 				).show();
 			internal_scope_guard lock;
 			_m_except_handler();

--- a/source/gui/programming_interface.cpp
+++ b/source/gui/programming_interface.cpp
@@ -326,7 +326,7 @@ namespace API
 
 		return nullptr;
 	}
-	//exit
+
 	//close all windows in current thread
 	void exit()
 	{
@@ -360,6 +360,42 @@ namespace API
 			}
 
 			for(auto i : roots)
+				interface_type::close_window(i);
+		}
+	}
+	//close all windows  
+	void exit_all()
+	{
+		std::vector<basic_window*> v;
+
+		internal_scope_guard lock;
+		restrict::wd_manager().all_handles(v);
+		if (v.size())
+		{
+			std::vector<native_window_type> roots;
+			native_window_type root = nullptr;
+			//unsigned tid = nana::system::this_thread_id();
+			for (auto wd : v)
+			{
+				if (/*(wd->thread_id == tid) &&*/ (wd->root != root))
+				{
+					root = wd->root;
+					bool exists = false;
+					for (auto i = roots.cbegin(); i != roots.cend(); ++i)
+					{
+						if (*i == root)
+						{
+							exists = true;
+							break;
+						}
+					}
+
+					if (!exists)
+						roots.push_back(root);
+				}
+			}
+
+			for (auto i : roots)
 				interface_type::close_window(i);
 		}
 	}

--- a/source/gui/wvl.cpp
+++ b/source/gui/wvl.cpp
@@ -17,7 +17,6 @@
 #include <iostream> 
 
 #define NANA_AUTOMATIC_GUI_TESTING
-
 namespace nana
 {
 	namespace detail

--- a/source/gui/wvl.cpp
+++ b/source/gui/wvl.cpp
@@ -29,6 +29,7 @@ namespace nana
 
 	void click(widget& w)
 	{
+		std::cout << "Automatically clicking widget "<<w.caption()<<":\n";
 		arg_click arg;
 		arg.window_handle = w.handle();
 		w.events().click.emit(arg);
@@ -37,8 +38,9 @@ namespace nana
 	/// in seconds
 	void Wait(unsigned wait)
 	{
-		if (wait)
-			std::this_thread::sleep_for(std::chrono::seconds{ wait });
+		if (!wait) return;
+		std::cout << "waiting " << wait << " sec...\n";
+		std::this_thread::sleep_for(std::chrono::seconds{ wait });
 	}
 
 	void pump()
@@ -57,23 +59,31 @@ namespace nana
 		//if (!wait)	
 		//	wait = 1;
 		//if (!main_form && !f)
-		//	f = []() {API::exit(); };
+		//	f = []() {API::exit_all(); };
 			
 	    std::cout << "Will wait " << wait << " sec...\n";
 	    std::thread t([wait, &f, wait_end, main_form]()
 		            { if (wait) 
 		                {   
-							std::cout << "Waiting " << wait << " sec...\n";
 							Wait( wait );
 							std::cout << "running... \n"  ;
-		                    if (f) f(); 
+							if (f)
+							{
+								f();
+								std::cout << "\nCongratulations, this was not trivial !" << std::endl;
+							}else
+							{
+								std::cout << "\nJust a trivial test." << std::endl;
+							}
 							std::cout << "Done... \n";
-							std::cout << "Now waiting anothers " << wait_end << " sec...\n";
+							std::cout << "Now again ";
 							Wait(wait_end);
-							std::cout << "Done... \n";
-							if (main_form)
-								 main_form->close();
-							API::exit();    // why not works?
+							std::cout << "Done... Now closing the main form...\n";
+							/*if (main_form)
+								 main_form->close();*/
+							std::cout << "Closed... Now API::exit ...\n";
+							API::exit_all();    // why not works?
+							std::cout << "Done... Upps - this had not to appear !! \n";
 						}
 		            });		
 		pump();

--- a/source/gui/wvl.cpp
+++ b/source/gui/wvl.cpp
@@ -16,7 +16,7 @@
 #include <thread>
 #include <iostream> 
 
-#define NANA_AUTOMATIC_GUI_TESTING
+//#define NANA_AUTOMATIC_GUI_TESTING
 namespace nana
 {
 	namespace detail

--- a/source/gui/wvl.cpp
+++ b/source/gui/wvl.cpp
@@ -14,18 +14,9 @@
 #include <nana/gui/wvl.hpp>
 #include <nana/gui/detail/bedrock.hpp>
 #include <thread>
-
 #include <iostream> 
 
-
-inline unsigned Wait_or_not(unsigned wait = 0)
-{
-#ifdef NANA_AUTOMATIC_GUI_TESTING
-	return wait;
-#else
-	return 0;
-#endif
-}
+#define NANA_AUTOMATIC_GUI_TESTING
 
 namespace nana
 {
@@ -37,38 +28,60 @@ namespace nana
 		}
 	}
 
-	void exec(unsigned wait, std::function<void()> f, unsigned wait_end, form *fm )
+	void click(widget& w)
 	{
-		#ifdef NANA_ADD_DEF_AUTOMATIC_GUI_TESTING
-				if (!wait)
-					wait = 10;
-				if (!f)
-					f = []() {API::exit(); };
-		#endif
+		arg_click arg;
+		arg.window_handle = w.handle();
+		w.events().click.emit(arg);
+	}
 
-		wait = Wait_or_not(wait);
+	/// in seconds
+	void Wait(unsigned wait)
+	{
+		if (wait)
+			std::this_thread::sleep_for(std::chrono::seconds{ wait });
+	}
 
-		std::cout << "Will wait " << wait << " sec...\n";
-		std::thread t([wait, &f, wait_end, fm]()
-		              { if (wait) 
-		                   {   
-							   std::cout << "Waiting " << wait << " sec...\n";
-							   std::this_thread::sleep_for(std::chrono::seconds{ wait } ); 
-							   std::cout << "running... \n"  ;
-		                       f(); 
-							   std::cout << "Done... \n";
-							   std::cout << "Now waiting anothers " << wait_end << " sec...\n";
-							   std::this_thread::sleep_for(std::chrono::seconds{ wait_end } );
-							   std::cout << "Done... \n";
-							   if (fm)
-								   fm->close();
-							   API::exit();    // why not works?
-						   }
-		              });
-		
+	void pump()
+	{
 		detail::bedrock::instance().pump_event(nullptr, false);
+	}
 
+
+	void exec(form *main_form, //= nullptr, ///< used to close the program
+		unsigned wait,         // = 1,      ///< for the GUI to be constructed, in seconds  
+		unsigned wait_end,     // = 1,      ///< for the GUI to be destructed, in seconds
+		std::function<void()>f // = {}      ///< emit events to mimics user actions and may asert results
+	)
+	{
+	#ifdef NANA_AUTOMATIC_GUI_TESTING
+		//if (!wait)	
+		//	wait = 1;
+		//if (!main_form && !f)
+		//	f = []() {API::exit(); };
+			
+	    std::cout << "Will wait " << wait << " sec...\n";
+	    std::thread t([wait, &f, wait_end, main_form]()
+		            { if (wait) 
+		                {   
+							std::cout << "Waiting " << wait << " sec...\n";
+							Wait( wait );
+							std::cout << "running... \n"  ;
+		                    if (f) f(); 
+							std::cout << "Done... \n";
+							std::cout << "Now waiting anothers " << wait_end << " sec...\n";
+							Wait(wait_end);
+							std::cout << "Done... \n";
+							if (main_form)
+								 main_form->close();
+							API::exit();    // why not works?
+						}
+		            });		
+		pump();
 		if (t.joinable())
 			t.join();
+    #else
+			pump();
+	#endif
 	}
 }//end namespace nana

--- a/source/gui/wvl.cpp
+++ b/source/gui/wvl.cpp
@@ -49,46 +49,39 @@ namespace nana
 	}
 
 
-	void exec(form *main_form, //= nullptr, ///< used to close the program
+	void exec(
 		unsigned wait,         // = 1,      ///< for the GUI to be constructed, in seconds  
 		unsigned wait_end,     // = 1,      ///< for the GUI to be destructed, in seconds
 		std::function<void()>f // = {}      ///< emit events to mimics user actions and may asert results
 	)
 	{
 	#ifdef NANA_AUTOMATIC_GUI_TESTING
-		//if (!wait)	
-		//	wait = 1;
-		//if (!main_form && !f)
-		//	f = []() {API::exit_all(); };
 			
 	    std::cout << "Will wait " << wait << " sec...\n";
-	    std::thread t([wait, &f, wait_end, main_form]()
-		            { if (wait) 
-		                {   
-							Wait( wait );
-							std::cout << "running... \n"  ;
-							if (f)
-							{
-								f();
-								std::cout << "\nCongratulations, this was not trivial !" << std::endl;
-							}else
-							{
-								std::cout << "\nJust a trivial test." << std::endl;
-							}
-							std::cout << "Done... \n";
-							std::cout << "Now again ";
-							Wait(wait_end);
-							std::cout << "Done... Now closing the main form...\n";
-							/*if (main_form)
-								 main_form->close();*/
-							std::cout << "Closed... Now API::exit ...\n";
-							API::exit_all();    // why not works?
-							std::cout << "Done... Upps - this had not to appear !! \n";
-						}
-		            });		
+
+	    std::thread t([wait, &f, wait_end]()
+			{ 
+				Wait( wait );
+				std::cout << "running... \n"  ;
+				if (f)
+				{
+					f();
+					std::cout << "\nCongratulations, this was not trivial !" << std::endl;
+				}else
+				{
+					std::cout << "\nJust a trivial test." << std::endl;
+				}
+				std::cout << "Done... \n";
+				std::cout << "Now again ";
+				Wait(wait_end);
+				std::cout << "Done... Now API::exit all ...\n";
+				API::exit_all();   
+			});		
+
 		pump();
 		if (t.joinable())
 			t.join();
+
     #else
 			pump();
 	#endif


### PR DESCRIPTION
[It is working good](https://travis-ci.org/qPCR4vir/nana/jobs/113431787).


We need to set this automatically in cmake. But first we need a general way to exit from an application from the parallel GUI testing function. Now I use `fm.close()`, and I need to pass a pointer to the main form to that function to do that. A general `API::exit()` will be much better but don't works. Why? With `API::exit()` nana can add a default GUI test to any program when compiled with that option, with is ideal for travis.  

Also, some demos compiled [but don't pass the run test](https://travis-ci.org/qPCR4vir/nana/jobs/113411795) - the list is at the end of `.travis.yml`. We need to fix that. It maybe a problem with [the Xvfb, an X server to emulate display](http://www.xfree86.org/4.0.1/Xvfb.1.html)? See hier [how to use in travis](https://docs.travis-ci.com/user/gui-and-headless-browsers/).
