### PR TITLE
a feature to load icon image data to image::open method

### DIFF
--- a/source/paint/image.cpp
+++ b/source/paint/image.cpp
@@ -100,7 +100,8 @@ namespace paint
 			{
 				close();
 #if defined(NANA_WINDOWS)
-				HICON handle = ::CreateIconFromResource((PBYTE)data, static_cast<DWORD>(bytes), TRUE, 0x00030000);
+				// use actual resource size, stopped using CreateIconFromResource since it loads blurry image
+				HICON handle = ::CreateIconFromResourceEx((PBYTE)data, static_cast<DWORD>(bytes), TRUE, 0x00030000, 0, 0, LR_DEFAULTCOLOR);
 				if(handle)
 				{
 					ICONINFO info;
@@ -357,6 +358,10 @@ namespace paint
 						else if (bytes > 9 && (0x66697845 == *reinterpret_cast<const unsigned*>(reinterpret_cast<const char*>(data)+5))) //Exif
 							ptr = std::make_shared<detail::image_jpeg>();
 #endif
+						// suppose icon data is bitmap data
+						if (!ptr && bytes > 40 /* sizeof(BITMAPINFOHEADER) */ && (40 == *reinterpret_cast<const uint32_t*>(data))) {
+							ptr = std::make_shared<detail::image_ico>(true);
+						}
 					}
 				}
 

--- a/source/paint/image.cpp
+++ b/source/paint/image.cpp
@@ -358,10 +358,13 @@ namespace paint
 						else if (bytes > 9 && (0x66697845 == *reinterpret_cast<const unsigned*>(reinterpret_cast<const char*>(data)+5))) //Exif
 							ptr = std::make_shared<detail::image_jpeg>();
 #endif
+
+#if defined(NANA_WINDOWS)
 						// suppose icon data is bitmap data
 						if (!ptr && bytes > 40 /* sizeof(BITMAPINFOHEADER) */ && (40 == *reinterpret_cast<const uint32_t*>(data))) {
 							ptr = std::make_shared<detail::image_ico>(true);
 						}
+#endif
 					}
 				}
 


### PR DESCRIPTION
Hi, this PR adds a feature to load icon image data to image::open method on Windows platform.

I also changed image_ico::open method so that it uses CreateIconFromResourceEx WindowsAPI
 instead of CreateIconFromResource. The reason is CreateIconFromResource makes loaded icon image blurry.

I checked issues #133 but loading icon image from exe file feature in nana::paint::create_image function is not adequate since I intend to use multiple icons from exe file resouce data.

By the way, I use below code to load resouce icons on Windows application.

```
void* load_icon_res(HMODULE hModule, int id, DWORD& dwResourceSize, int cxDesired, int cyDesired)
{
	auto hResource		= FindResource(hModule, MAKEINTRESOURCE(id), RT_GROUP_ICON);	if (!hResource) { return nullptr; }
	dwResourceSize		= SizeofResource(hModule, hResource);							if (dwResourceSize == 0) { return nullptr; }
	auto hData			= LoadResource(hModule, hResource);								if (!hData) { return nullptr; }
	auto pResource		= LockResource(hData);											if (!pResource) { return nullptr; }
	id					= LookupIconIdFromDirectoryEx((LPBYTE)pResource,
													  TRUE,
													  cxDesired,
													  cyDesired,
													  LR_DEFAULTCOLOR);					if (id == 0) { return nullptr; }
	hResource			= FindResource(hModule, MAKEINTRESOURCE(id), RT_ICON);			if (!hResource) { return nullptr; }
	dwResourceSize		= SizeofResource(hModule, hResource);							if (dwResourceSize == 0) { return nullptr; }
	hData				= LoadResource(hModule, hResource);								if (!hData) { return nullptr; }
	pResource			= LockResource(hData);
	return pResource;
}

nana::paint::image img_big_icon;
nana::paint::image img_small_icon;
DWORD resource_size_big = 0;
DWORD resource_size_small = 0;
void* res_big_icon = load_icon_res(NULL, IDI_ICON1, resource_size_big, GetSystemMetrics(SM_CXICON), GetSystemMetrics(SM_CYICON));
void* res_small_icon = load_icon_res(NULL, IDI_ICON1, resource_size_small, GetSystemMetrics(SM_CXSMICON), GetSystemMetrics(SM_CYSMICON));
if (res_big_icon && res_small_icon) {
	if (img_big_icon.open(res_big_icon, resource_size_big)
		&& img_small_icon.open(res_small_icon, resource_size_small)
	) {
		nana::API::window_icon_default(img_small_icon, img_big_icon);
	}
}
```