### PR TITLE
Fixed behavior of disabled items in the menus when scrolling with arrow keys.

### DIFF
--- a/source/gui/widgets/menu.cpp
+++ b/source/gui/widgets/menu.cpp
@@ -475,7 +475,7 @@ namespace nana
 								--pos;
 						}
 
-						if(! menu_->items.at(pos).flags.splitter)
+						if(! menu_->items.at(pos).flags.splitter && menu_->items.at(pos).flags.enabled)
 							break;
 					}
 


### PR DESCRIPTION
Used same behavior for the splitter.