### PR TITLE
vs"15" fix

### DIFF
--- a/include/nana/c++defines.hpp
+++ b/include/nana/c++defines.hpp
@@ -102,7 +102,7 @@
 	#define _CRT_SECURE_NO_DEPRECATE
 	#pragma warning(disable : 4996)
 
-	#if (_MSC_VER == 1900)
+	#if (_MSC_VER >= 1900)
 		// google: break any code that tries to use codecvt<char16_t> or codecvt<char32_t>.
 		// google: It appears the C++ libs haven't been compiled with native char16_t/char32_t support.
 		// google: Those definitions are for codecvt<wchar_t>::id, codecvt<unsigned short>::id and codecvt<char>::id respectively.


### PR DESCRIPTION
nana is not compilable for Visual Studio 15.
This fixes it in c++defines.hpp.
This was not working because the _MSC_VER for VS15 exposes to 1910.