### PR TITLE
Added two features to the Listbox:

### DIFF
--- a/include/nana/gui/widgets/listbox.hpp
+++ b/include/nana/gui/widgets/listbox.hpp
@@ -838,6 +838,7 @@ namespace nana
 				std::string	text(size_type col) const;
 
 				void icon(const nana::paint::image&);
+				bool icon() const;
 
 				template<typename T>
 				item_proxy & resolve_from(const T& t)
@@ -1111,6 +1112,14 @@ namespace nana
 		arg_listbox(const drawerbase::listbox::item_proxy&) noexcept;
 	};
 
+	struct arg_listbox_scroll
+		: public event_arg
+	{
+		mutable drawerbase::listbox::item_proxy item;
+
+		arg_listbox_scroll(const drawerbase::listbox::item_proxy&) noexcept;
+	};
+
 	/// The event parameter type for listbox's category_dbl_click
 	struct arg_listbox_category
 		: public event_arg
@@ -1138,6 +1147,9 @@ namespace nana
 
 				/// An event occurs when a listbox category is double clicking.
 				basic_event<arg_listbox_category> category_dbl_click;
+
+				/// An event occurs when a listbox is scrolled.
+				basic_event<arg_listbox_scroll> scrolled;
 			};
 
 			struct scheme

--- a/source/gui/widgets/listbox.cpp
+++ b/source/gui/widgets/listbox.cpp
@@ -773,6 +773,17 @@ namespace nana
 						p->inline_ptr->notify_status(inline_widget_status::selecting, i.selected());
 				}
 
+				void emit_scrolled(index_pair pos)
+				{
+					item_proxy i(ess_, pos);
+					arg_listbox_scroll arg{ i };
+					wd_ptr()->events().scrolled.emit(arg, wd_ptr()->handle());
+
+//					auto panes = get_inline_pane(pos);
+//					for (auto p : panes)
+//						p->inline_ptr->notify_status(inline_widget_status::selecting, i.selected());
+				}
+
 				// Definition is provided after struct essence
 				unsigned column_content_pixels(size_type pos) const;
 
@@ -2412,6 +2423,7 @@ namespace nana
 								return;
 
 							set_scroll_y_dpl(item);
+							lister.emit_scrolled(scroll.offset_y_dpl);
 						}
 
 						API::refresh_window(this->lister.wd_ptr()->handle());
@@ -4557,6 +4569,11 @@ namespace nana
 					return cat_->items.at(pos_.item).flags.checked;
 				}
 
+				bool item_proxy::icon() const
+				{
+					return !cat_->items.at(pos_.item).img.empty();
+				}
+
 				/// is ignored if no change (maybe set last_selected anyway??), but if change emit event, deselect others if need ans set/unset last_selected
 				item_proxy & item_proxy::select(bool sel, bool scroll_view)
 				{
@@ -5198,6 +5215,10 @@ namespace nana
 		: item(m)
 	{
 	}
+
+	arg_listbox_scroll::arg_listbox_scroll(const drawerbase::listbox::item_proxy& m) noexcept
+		: item(m)
+	{}
 
 
 	//Implementation of arg_listbox_category


### PR DESCRIPTION
- "bool icon()" function to check if a valid image is already present.
- Event scrolled(): Event that takes place when you act on the vertical scroll bar.
The return argument of the function is the first item displayed (index_pair is relative and not absolute).
**Note**: It's not handled notity_status for inline_widget, not being sure that it will be useful.