### PR TITLE
Include cstring header on image_png.hpp

### DIFF
--- a/source/paint/detail/image_png.hpp
+++ b/source/paint/detail/image_png.hpp
@@ -2,6 +2,7 @@
 #define NANA_PAINT_DETAIL_IMAGE_PNG_HPP
 
 #include "image_pixbuf.hpp"
+#include <cstring>
 
 //Separate the libpng from the package that system provides.
 #if defined(NANA_LIBPNG)


### PR DESCRIPTION
Compilation was failing with the "enable png" flag. This was happening
because the memcpy function was being called without the inclusion of
cstring, which declares it. This fixes it.