### PR TITLE
Fix STRING2 macro to handle defined macros with no value

### DIFF
--- a/include/nana/verbose_preprocessor.hpp
+++ b/include/nana/verbose_preprocessor.hpp
@@ -30,9 +30,9 @@
 
 
 
-    #define STRING2(x) #x
+    #define STRING2(...) #__VA_ARGS__
 	#define STRING(x) STRING2(x)
-    #define SHOW_VALUE(x) " " #x "  =  " STRING2(x) 
+    #define SHOW_VALUE(x) " " #x "  =  " STRING2(x)
 
 	#pragma message ( "\n -----> Verbose preprocessor"  )
 	#pragma message (  SHOW_VALUE(VERBOSE_PREPROCESSOR)  )
@@ -124,7 +124,7 @@
 	#pragma message (  SHOW_VALUE(USE_LIBJPEG_FROM_OS)  )
 	#pragma message (  SHOW_VALUE(NANA_LIBJPEG)  )
 
-   
+
    // #pragma message ( "\n =" STRING() ", \n =" STRING()"  , \n =" STRING() )
 
     #if defined(STOP_VERBOSE_PREPROCESSOR)


### PR DESCRIPTION
In `nana\verbose_preprocessor.hpp` there is a STRING2 macro to convert macro values to string. 
However, this emits a warning when the latter macro is defined but has no value. For example: 

```
    #define STRING2(x) #x
    #define SHOW_VALUE(x) " " #x "  =  " STRING2(x) 

    SHOW_VALUE(NANA_WINDOWS)
```

This emits C4003 because NANA_WINDOWS is defined but has no value. 
Also applies to _UNICODE and UNICODE (also in `nana\verbose_preprocessor.hpp`)
```
E:\workspace\vcpkgspace\buildtrees\nana\src\nana\include\nana/verbose_preprocessor.hpp(45): warning C4003: not enough actual parameters for macro 'STRING2' (compiling source file E:\workspace\vcpkgspace\buildtrees\nana\src\nana\source\deploy.cpp) [E:\workspace\vcpkgspace\buildtrees\nana\x86-windows-test-rel\nana.vcxproj]
E:\workspace\vcpkgspace\buildtrees\nana\src\nana\include\nana/verbose_preprocessor.hpp(115): warning C4003: not enough actual parameters for macro 'STRING2' (compiling source file E:\workspace\vcpkgspace\buildtrees\nana\src\nana\source\deploy.cpp) [E:\workspace\vcpkgspace\buildtrees\nana\x86-windows-test-rel\nana.vcxproj]
E:\workspace\vcpkgspace\buildtrees\nana\src\nana\include\nana/verbose_preprocessor.hpp(116): warning C4003: not enough actual parameters for macro 'STRING2' (compiling source file E:\workspace\vcpkgspace\buildtrees\nana\src\nana\source\deploy.cpp) [E:\workspace\vcpkgspace\buildtrees\nana\x86-windows-test-rel\nana.vcxproj]
