### PR TITLE
Fixed build error

### DIFF
--- a/include/nana/gui/detail/native_window_interface.hpp
+++ b/include/nana/gui/detail/native_window_interface.hpp
@@ -16,6 +16,8 @@
 #include "../basis.hpp"
 #include <nana/paint/image.hpp>
 
+#include <functional>
+
 namespace nana
 {
 namespace detail


### PR DESCRIPTION
compiler didn't understand std::function
included ```<functional>``` as a fix