### PR TITLE
Fixed stdc++.hpp build error on gcc 7

### DIFF
--- a/include/nana/c++defines.hpp
+++ b/include/nana/c++defines.hpp
@@ -195,6 +195,8 @@
 #	endif
 #endif
 
+// std::clamp's feature test macro is defined inside <algorithm> 
+#include <algorithm>
 #if (!defined(__cpp_lib_clamp)) || (__cpp_lib_clamp < 201603)
 #	ifndef _enable_std_clamp
 #		define _enable_std_clamp


### PR DESCRIPTION
included algorithm in c++defines.hpp
this fixes std::clamp's feature test which was not working.

__cpp_lib_clamp is defined inside ```<algorithm>```.
Not include ```<algorithm>``` before the feature test introduced the problem.