### PR TITLE
Inputbox set minimum width entry field

### DIFF
--- a/include/nana/gui/msgbox.hpp
+++ b/include/nana/gui/msgbox.hpp
@@ -46,7 +46,7 @@ namespace nana
 		/// Construct that creates a message box with a specified title and default button.
 		msgbox(const ::std::string&);
 
-		/// Construct that creates a message box with an owner windoow, a specified title and buttons. 
+		/// Construct that creates a message box with an owner windoow, a specified title and buttons.
 		msgbox(window, const ::std::string&, button_t = ok);
 
 		/// Sets an icon for informing user.
@@ -108,6 +108,7 @@ namespace nana
 			virtual window create(window, unsigned label_px) = 0;
 			virtual unsigned fixed_pixels() const;
 		};
+
 	public:
 		class boolean
 			: public abstract_content
@@ -240,7 +241,6 @@ namespace nana
 		{
 			std::vector<abstract_content*> contents;
 			_m_fetch_args(contents, std::forward<Args>(args)...);
-			
 			if (contents.empty())
 				return false;
 
@@ -261,6 +261,14 @@ namespace nana
 
 		/// Sets a verifier to verify the user input.
 		void verify(std::function<bool(window)> verifier);
+
+		/** Sets the minimum width for the entry fields
+            @param[in] pixels  new minimum width
+
+            If not called, the default is 100 pixels
+        */
+		void min_width_entry_field( int pixels );
+
 	private:
 		void _m_fetch_args(std::vector<abstract_content*>&);
 
@@ -279,6 +287,7 @@ namespace nana
 		std::function<bool(window)> verifier_;
 		::nana::paint::image images_[4];
 		::nana::rectangle valid_areas_[4];
+        int min_width_entry_field_pixels_;
 	};
 }//end namespace nana
 #include <nana/pop_ignore_diagnostic>

--- a/source/gui/msgbox.cpp
+++ b/source/gui/msgbox.cpp
@@ -685,7 +685,7 @@ namespace nana
 	{
 		return impl_->empty_label_text;
 	}
-	
+
 	window inputbox::boolean::create(window owner, unsigned label_px)
 	{
 		auto impl = impl_.get();
@@ -1258,7 +1258,8 @@ namespace nana
 	inputbox::inputbox(window owner, ::std::string desc, ::std::string title)
 		:	owner_{ owner },
 			description_(std::move(desc)),
-			title_(std::move(title))
+			title_(std::move(title)),
+			min_width_entry_field_pixels_( 100 )
 	{}
 
 	void inputbox::image(::nana::paint::image img, bool is_left, const rectangle& valid_area)
@@ -1278,6 +1279,15 @@ namespace nana
 	void inputbox::verify(std::function<bool(window)> verifier)
 	{
 		verifier_ = std::move(verifier);
+	}
+
+	void inputbox::min_width_entry_field( int pixels )
+	{
+	    // don't let the entry fields vanish entirely
+	    if( pixels < 10 )
+            pixels = 10;
+
+        min_width_entry_field_pixels_ = pixels;
 	}
 
 	void inputbox::_m_fetch_args(std::vector<abstract_content*>&)
@@ -1304,9 +1314,9 @@ namespace nana
 			each_pixels.push_back(px.height);
 		}
 
-		//Adjust the fixed_px for good looking
-		if (has_0_fixed_px && (fixed_px < 100))
-			fixed_px = 100;
+		//Ensure that the entry fields are at least as wide as the minimum
+		if (has_0_fixed_px && (fixed_px < min_width_entry_field_pixels_ ))
+			fixed_px = min_width_entry_field_pixels_;
 
 		inputbox_window input_wd(owner_, images_, valid_areas_, description_, title_, contents.size(), label_px + 10 + fixed_px, each_pixels);
 


### PR DESCRIPTION
V1.5.4 increased the default minimum width of the entry fields in inputbox to a sensible value of 100 pixels.  However, we sometimes need even wider fields  than this, but it would be weird to make the default any wider than 100 pixels.  This add a setter to increase the width when needed.