### PR TITLE
use std::thread if gcc is compiled with c++11 threading support

### DIFF
--- a/include/nana/std_mutex.hpp
+++ b/include/nana/std_mutex.hpp
@@ -14,8 +14,12 @@
 #include <cstdio>
 // http://lxr.free-electrons.com/source/include/uapi/asm-generic/errno.h#L53
 //#define EPROTO          71      /* Protocol error */
+#ifdef _GLIBCXX_HAS_GTHREADS
+#    include <thread>
+#else
 #include <mingw.thread.h>
 #include <mingw.mutex.h>
+#endif
 #else
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/recursive_mutex.hpp>

--- a/include/nana/std_thread.hpp
+++ b/include/nana/std_thread.hpp
@@ -6,7 +6,11 @@
 
 #if defined(NANA_ENABLE_MINGW_STD_THREADS_WITH_MEGANZ)
 
-#include <mingw.thread.h>
+#ifdef _GLIBCXX_HAS_GTHREADS
+#    include <thread>
+#else
+#    include <mingw.thread.h>
+#endif
 #else
 #include <boost/thread.hpp>
 namespace std


### PR DESCRIPTION
NANA_CMAKE_ENABLE_MINGW_STD_THREADS_WITH_MEGANZ option must still be enabled but mingw.thread.h and mingw.mutex.h will be ignored if _GLIBCXX_HAS_GTHREADS is defined