### PR TITLE
Fix XIM cursor follow issue under X11

### DIFF
--- a/source/detail/platform_spec_posix.cpp
+++ b/source/detail/platform_spec_posix.cpp
@@ -835,19 +835,19 @@ namespace detail
 			i->second->reinstate();
 			i->second->pos = pos;
 		}
-        auto addr = i->second;
-        XPoint spot;
-        XVaNestedList list;
-        if(addr->input_context) {
-            spot.x = pos.x;
-            spot.y = pos.y + addr->size.height;
-            list = ::XVaCreateNestedList(0, XNSpotLocation, &spot,
-                        XNForeground, 0,
-                        XNBackground, 0,
-                        (void *)0);
-            ::XSetICValues(addr->input_context, XNPreeditAttributes, list, NULL);
-            ::XFree(list);
-        }
+		auto addr = i->second;
+		XPoint spot;
+		XVaNestedList list;
+		if(addr->input_context) {
+			spot.x = pos.x;
+			spot.y = pos.y + addr->size.height;
+			list = ::XVaCreateNestedList(0, XNSpotLocation, &spot,
+					XNForeground, 0,
+					XNBackground, 0,
+					(void *)0);
+			::XSetICValues(addr->input_context, XNPreeditAttributes, list, NULL);
+			::XFree(list);
+		}
 	}
 
 	void platform_spec::caret_visible(native_window_type wd, bool vis)

--- a/source/detail/platform_spec_posix.cpp
+++ b/source/detail/platform_spec_posix.cpp
@@ -835,6 +835,19 @@ namespace detail
 			i->second->reinstate();
 			i->second->pos = pos;
 		}
+        auto addr = i->second;
+        XPoint spot;
+        XVaNestedList list;
+        if(addr->input_context) {
+            spot.x = pos.x;
+            spot.y = pos.y + addr->size.height;
+            list = ::XVaCreateNestedList(0, XNSpotLocation, &spot,
+                        XNForeground, 0,
+                        XNBackground, 0,
+                        (void *)0);
+            ::XSetICValues(addr->input_context, XNPreeditAttributes, list, NULL);
+            ::XFree(list);
+        }
 	}
 
 	void platform_spec::caret_visible(native_window_type wd, bool vis)


### PR DESCRIPTION
update XIM spot location to follow current caret position, fix XIM OverTheSpot cursor following issue.

These changes are harmless even XIC not OverTheSpot style.