### PR TITLE
fix compilation with boost::filesystem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,9 @@ matrix:
             - libx11-dev
             - libxft-dev
             - libboost-filesystem-dev
+            - libboost-system-dev
+            - libboost-thread-dev
+            - libboost-chrono-dev
           sources: 
             - ubuntu-toolchain-r-test
             

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,7 +238,7 @@ elseif (NANA_CMAKE_STD_FILESYSTEM_FORCE)
     add_definitions(-DSTD_FILESYSTEM_FORCE)
 elseif (NANA_CMAKE_FIND_BOOST_FILESYSTEM OR NANA_CMAKE_BOOST_FILESYSTEM_FORCE)
     if (NANA_CMAKE_BOOST_FILESYSTEM_FORCE)
-        add_definitions(-DNANA_BOOST_FILESYSTEM_FORCE)
+        add_definitions(-DBOOST_FILESYSTEM_FORCE)
     endif(NANA_CMAKE_BOOST_FILESYSTEM_FORCE)
     # https://cmake.org/cmake/help/git-master/module/FindBoost.html
     # Implicit dependencies such as Boost::filesystem requiring Boost::system will be automatically detected and satisfied,
@@ -246,7 +246,7 @@ elseif (NANA_CMAKE_FIND_BOOST_FILESYSTEM OR NANA_CMAKE_BOOST_FILESYSTEM_FORCE)
     # If using Boost::thread, then Thread::Thread will also be added automatically.
     find_package(Boost COMPONENTS filesystem)
     if (Boost_FOUND)
-        add_definitions(-DNANA_BOOST_FILESYSTEM_AVAILABLE)
+        add_definitions(-DBOOST_FILESYSTEM_AVAILABLE)
         include_directories(SYSTEM "${Boost_INCLUDE_DIR}")
         list(APPEND NANA_LINKS ${Boost_LIBRARIES})    ######  FIRST !!!!!!!!!!!!!!!!!    add   is not first
     endif (Boost_FOUND)

--- a/include/nana/filesystem/filesystem.hpp
+++ b/include/nana/filesystem/filesystem.hpp
@@ -53,6 +53,7 @@
 
 #undef  NANA_USING_BOOST_FILESYSTEM
 #define NANA_USING_BOOST_FILESYSTEM 1
+#   include <chrono>
 #   include <boost/filesystem.hpp>
 
 // add boost::filesystem into std::experimental::filesystem
@@ -60,6 +61,20 @@ namespace std {
 	namespace experimental {
 		namespace filesystem {
 			using namespace boost::filesystem;
+			using file_time_type = std::chrono::time_point<std::chrono::system_clock>;
+
+			enum class file_type {
+				none = boost::filesystem::file_type::status_unknown,
+				not_found = boost::filesystem::file_type::file_not_found,
+				regular = boost::filesystem::file_type::regular_file,
+				directory = boost::filesystem::file_type::directory_file,
+				symlink = boost::filesystem::file_type::symlink_file,
+				block = boost::filesystem::file_type::block_file,
+				character = boost::filesystem::file_type::character_file,
+				fifo = boost::filesystem::file_type::fifo_file,
+				socket = boost::filesystem::file_type::socket_file,
+				unknown = boost::filesystem::file_type::type_unknown,
+			};
 		} // filesystem
 	} // experimental
 } // std

--- a/include/nana/stdc++.hpp
+++ b/include/nana/stdc++.hpp
@@ -12,6 +12,9 @@
  *	@brief Implement the lack support of standard library.
  */
 
+#ifndef NANA_STDCXX_INCLUDED
+#define NANA_STDCXX_INCLUDED
+
 #include "c++defines.hpp"
 
 //Implement workarounds for GCC/MinGW which version is below 4.8.2
@@ -154,3 +157,5 @@ namespace std
 	}
 }
 #endif
+
+#endif // NANA_STDCXX_INCLUDED

--- a/source/filesystem/filesystem.cpp
+++ b/source/filesystem/filesystem.cpp
@@ -14,7 +14,13 @@
 #include <nana/filesystem/filesystem_ext.hpp>
 #include <vector>
 #include <sstream>
-#include <iomanip>	//put_time
+
+#include <nana/config.hpp>
+#ifdef _enable_std_put_time
+	#include <nana/stdc++.hpp>
+#else
+	#include <iomanip>
+#endif
 
 #if defined(NANA_WINDOWS)
     #include <windows.h>
@@ -97,7 +103,13 @@ namespace nana
 		std::string pretty_file_date(const fs::path& path) // todo: move to .cpp
 		{
 			try {
+#if NANA_USING_BOOST_FILESYSTEM
+				// The return type of boost::filesystem::last_write_time isn't
+				// the same as in nana and std implementations of this function
+				auto ftime = std::chrono::system_clock::from_time_t(fs::last_write_time(path));
+#else
 				auto ftime = fs::last_write_time(path);
+#endif
 
 				// crash: VS2015 will not read the time for some files (for example: C:/hiberfil.sys)
 				//   and will return file_time_type(-1) without throwing

--- a/source/gui/filebox.cpp
+++ b/source/gui/filebox.cpp
@@ -505,21 +505,18 @@ namespace nana
 
 				auto fpath = i->path().native();
 				auto fattr = fs::status(fpath);
+				auto ftype = static_cast<fs::file_type>(fattr.type());
 
 				item_fs m;
 				m.name = name;
 				m.directory = fs::is_directory(fattr);
 
-				switch(fattr.type())
-				{
-				case fs::file_type::not_found:
-				case fs::file_type::unknown:
-				case fs::file_type::directory:
+				if (ftype == fs::file_type::not_found ||
+					ftype == fs::file_type::unknown ||
+					ftype == fs::file_type::directory)
 					m.bytes = 0;
-					break;
-				default:
+				else
 					m.bytes = fs::file_size(fpath);
-				}
 
 				fs_ext::modified_file_time(fpath, m.modified_time);
 				
@@ -692,13 +689,12 @@ namespace nana
 					return;
 				}
 
-				using file_type = fs::file_type;
-
 				fs::path fspath(fb_.addr_.filesystem + path);
 
-				auto fst = fs::status(fspath);
+				auto fattr = fs::status(fspath);
+				auto ftype = static_cast<fs::file_type>(fattr.type());
 
-				if(fst.type() != file_type::not_found && fst.type() != file_type::none)
+				if(ftype != fs::file_type::not_found && ftype != fs::file_type::none)
 				{
 					mb<<i18n("NANA_FILEBOX_ERROR_RENAME_FOLDER_BECAUSE_OF_EXISTING");
 					mb();
@@ -800,6 +796,7 @@ namespace nana
 						tar = addr_.filesystem + file;
 
 					auto fattr = fs::status(tar);
+					auto ftype = static_cast<fs::file_type>(fattr.type());
 
 					//Check if the selected name is a directory
 					auto is_dir = fs::is_directory(fattr);
@@ -808,6 +805,7 @@ namespace nana
 					{
 						//Add the extension, then check if it is a directory again.
 						fattr = fs::status(tar);
+						ftype = static_cast<fs::file_type>(fattr.type());
 						is_dir = fs::is_directory(fattr);
 					}
 					
@@ -820,7 +818,7 @@ namespace nana
 
 					if(io_read_)
 					{
-						if(fs::file_type::not_found == fattr.type())
+						if(fs::file_type::not_found == ftype)
 						{
 							msgbox mb(*this, caption());
 							mb.icon(msgbox::icon_information);
@@ -832,7 +830,7 @@ namespace nana
 					}
 					else
 					{
-						if(fs::file_type::not_found != fattr.type())
+						if(fs::file_type::not_found != ftype)
 						{
 							msgbox mb(*this, caption(), msgbox::yes_no);
 							mb.icon(msgbox::icon_question);

--- a/source/gui/wvl.cpp
+++ b/source/gui/wvl.cpp
@@ -15,7 +15,12 @@
 #include <nana/gui/detail/bedrock.hpp>
 #include <nana/std_thread.hpp>
 #include <iostream> 
-#include <chrono>
+
+#ifdef STD_THREAD_NOT_SUPPORTED
+#	include <boost/chrono.hpp>
+#else
+#	include <chrono>
+#endif
 
 //#define NANA_AUTOMATIC_GUI_TESTING
 namespace nana


### PR DESCRIPTION
see qPCR4vir/nana-demo#13 for related nana-demo changes, without them travis build is always going to fail on tests.

Travis build succeeded with this PR and changes to nana-demo applied:
https://travis-ci.org/pavelxdd/nana/builds/308570743

CMakeLists.txt:
---------------------------
Until now build with boost::filesystem was completely broken,
since cmake exported definitions with wrong name prefixes, and
nana always defaulted to internal filesystem implementation.

After fixing the boost definitions, a number of errors came up
due to incompatibility of boost::filesystem with nana and std
filesystems. This commit tries to fix them all.

filesystem.cpp, filesystem.hpp, filebox.cpp:
--------------------------------------------
boost::filesystem doesn't have a file_time_type, so declared
it in the filesystem.hpp header.

boost::filesystem::last_write_time has a return type std::time_t
unlike the other two implementations of this function in nana
and std, so added ifdef to convert the result to file_time_type.

fixed build on gcc-4.9, since it doesn't have a std::put_time
function, included <nana/stdc++.hpp> in that case.

boost::filesystem::file_type types have different names than
std::experimental::filesystem::file_type types, fixed it by
creating an enum class file_type with the same type names as
in std::experimental::filesystem::file_type. This fix
requires static_cast from functions results to internal file_type,
since boost file_type and std file_type a different enum classes.

changed switch to if, bacause old gcc fails on converting
enum class members to int.

stdc++.hpp:
-----------
added ifndef guards to prevent errors on multiple includes of this header.

wvl.cpp:
--------
added boost/chrono.hpp include for the cases when std::thread is not
available.

travis:
-------
added boost system, thread, chrono libs to install, they are needed
for the nana-demo to compile.