### PR TITLE
Make more Linux distros happy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,7 +131,7 @@ endif(APPLE)
 
 if(UNIX)
     list(APPEND NANA_LINKS -lX11)
-    find_package(Freetype)
+    include(FindFreetype)
     if (FREETYPE_FOUND)
         include_directories( ${FREETYPE_INCLUDE_DIRS})
         list(APPEND NANA_LINKS -lXft)


### PR DESCRIPTION
Specifically, making Nana C++ in Fefora 27 will complain about missing <ft2build.h>, and so will Solus.

The following distros have been tested against the change:
Arch Linux, Manjaro, Ubuntu, Fedora, Solus