### PR TITLE
Develop. Fix travis test/demos with gcc 4.9 and boost 1.54

### DIFF
--- a/build/vc2017/nana.vcxproj
+++ b/build/vc2017/nana.vcxproj
@@ -101,6 +101,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -113,6 +114,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -127,6 +129,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -143,6 +146,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/build/vc2017/nana.vcxproj.filters
+++ b/build/vc2017/nana.vcxproj.filters
@@ -41,6 +41,9 @@
     <Filter Include="Sources\threads">
       <UniqueIdentifier>{c1cdf46a-519f-422a-947f-39e173045414}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Headers">
+      <UniqueIdentifier>{d87c71b7-71e7-4221-953e-783325beffe4}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\source\any.cpp">

--- a/include/nana/filesystem/filesystem.hpp
+++ b/include/nana/filesystem/filesystem.hpp
@@ -75,6 +75,16 @@ namespace std {
 				socket = boost::filesystem::file_type::socket_file,
 				unknown = boost::filesystem::file_type::type_unknown,
 			};
+			/// enable directory_iterator range-based for statements
+			inline directory_iterator begin(directory_iterator iter) noexcept
+			{
+				return iter;
+			}
+
+			inline directory_iterator end(const directory_iterator&) noexcept
+			{
+				return {};
+			}
 		} // filesystem
 	} // experimental
 } // std

--- a/include/nana/filesystem/filesystem.hpp
+++ b/include/nana/filesystem/filesystem.hpp
@@ -55,6 +55,37 @@
 #define NANA_USING_BOOST_FILESYSTEM 1
 #   include <chrono>
 #   include <boost/filesystem.hpp>
+// dont include generic_u8string
+// http://www.boost.org/doc/libs/1_66_0/boost/filesystem/path.hpp
+// enable directory_iterator C++11 range-base for 
+// http://www.boost.org/doc/libs/1_66_0/boost/filesystem/operations.hpp
+// but travis come with an oooold version of boost
+// NOT enable directory_iterator C++11 range-base for
+// http://www.boost.org/doc/libs/1_54_0/boost/filesystem/operations.hpp
+namespace boost
+{
+	namespace filesystem
+	{
+
+		//  enable directory_iterator C++11 range-base for statement use  --------------------//
+
+		//  begin() and end() are only used by a range-based for statement in the context of
+		//  auto - thus the top-level const is stripped - so returning const is harmless and
+		//  emphasizes begin() is just a pass through.
+		inline
+		const directory_iterator& begin(const directory_iterator& iter) BOOST_NOEXCEPT
+		{
+			return iter;
+		}
+		inline
+		directory_iterator end(const directory_iterator&) BOOST_NOEXCEPT
+		{
+			return directory_iterator();
+		}
+
+	}  // namespace filesystem
+}   
+
 
 // add boost::filesystem into std::experimental::filesystem
 namespace std {
@@ -76,15 +107,15 @@ namespace std {
 				unknown = boost::filesystem::file_type::type_unknown,
 			};
 			/// enable directory_iterator range-based for statements
-			inline directory_iterator begin(directory_iterator iter) noexcept
-			{
-				return iter;
-			}
+			//inline directory_iterator begin(directory_iterator iter) noexcept
+			//{
+			//	return iter;
+			//}
 
-			inline directory_iterator end(const directory_iterator&) noexcept
-			{
-				return {};
-			}
+			//inline directory_iterator end(const directory_iterator&) noexcept
+			//{
+			//	return {};
+			//}
 		} // filesystem
 	} // experimental
 } // std

--- a/include/nana/filesystem/filesystem_ext.hpp
+++ b/include/nana/filesystem/filesystem_ext.hpp
@@ -16,6 +16,8 @@
 #define NANA_FILESYSTEM_EXT_HPP
 
 #include <nana/filesystem/filesystem.hpp>
+#include <nana/deploy.hpp>
+
 
 namespace nana 
 {

--- a/include/nana/filesystem/filesystem_ext.hpp
+++ b/include/nana/filesystem/filesystem_ext.hpp
@@ -34,6 +34,16 @@ namespace filesystem_ext
  
 std::experimental::filesystem::path path_user();    ///< extention ?
 
+/// workaround Boost not having path.generic_u8string() - a good point for http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0251r0.pdf
+inline std::string generic_u8string(const std::experimental::filesystem::path& p) 
+{ 
+  #if NANA_USING_BOOST_FILESYSTEM
+	 return nana::to_utf8(p.generic_wstring());
+  #else
+	 return p.generic_u8string();
+  #endif
+}
+
 inline bool is_directory(const std::experimental::filesystem::directory_entry& dir) noexcept
 {
     return is_directory(dir.status());

--- a/include/nana/gui/widgets/listbox.hpp
+++ b/include/nana/gui/widgets/listbox.hpp
@@ -987,9 +987,13 @@ namespace nana
 				cat_proxy(essence*, size_type pos) noexcept;
 				cat_proxy(essence*, category_t*) noexcept;
 
-				/// Append an item at abs end of the category, set_value determines whether assign T object to the value of item.
-				template<typename T>
-				item_proxy append(T&& t, bool set_value = false)
+				/// Append an item at the end of this category using the oresolver to generate the texts to be put in each column.
+                ///
+                /// First you have to make sure there is an overload of the operator<<() of the oresolver for the type of the object used here
+                /// If a listbox have a model set, try call append_model instead.
+                template<typename T>
+				item_proxy append(  T&& t,                  ///< Value used by the resolver to generate the texts to be put in each column of the item
+                                    bool set_value = false) ///< determines whether to set the object as the value of this item.
 				{
 					oresolver ores(ess_);
 
@@ -1039,7 +1043,7 @@ namespace nana
 
 				model_guard model();
 
-				/// Appends one item at the end of this category with the specifies text in the column fields
+				/// Appends one item at the end of this category with the specifies texts in the column fields
 				void append(std::initializer_list<std::string> texts_utf8);
 				void append(std::initializer_list<std::wstring> texts);
 


### PR DESCRIPTION
This is a variation on #281 
Finally it works. But do not worry too much about this. We will soon retire support for boost / filesystem and for gcc 4.9
