### PR TITLE
develop-c++17: Fix travis test/demos with gcc 4.9 and boost 1.54

### DIFF
--- a/include/nana/filesystem/filesystem.hpp
+++ b/include/nana/filesystem/filesystem.hpp
@@ -55,6 +55,37 @@
 #define NANA_USING_BOOST_FILESYSTEM 1
 #   include <chrono>
 #   include <boost/filesystem.hpp>
+// dont include generic_u8string
+// http://www.boost.org/doc/libs/1_66_0/boost/filesystem/path.hpp
+// enable directory_iterator C++11 range-base for 
+// http://www.boost.org/doc/libs/1_66_0/boost/filesystem/operations.hpp
+// but travis come with an oooold version of boost
+// NOT enable directory_iterator C++11 range-base for
+// http://www.boost.org/doc/libs/1_54_0/boost/filesystem/operations.hpp
+namespace boost
+{
+	namespace filesystem
+	{
+
+		//  enable directory_iterator C++11 range-base for statement use  --------------------//
+
+		//  begin() and end() are only used by a range-based for statement in the context of
+		//  auto - thus the top-level const is stripped - so returning const is harmless and
+		//  emphasizes begin() is just a pass through.
+		inline
+			const directory_iterator& begin(const directory_iterator& iter) BOOST_NOEXCEPT
+		{
+			return iter;
+		}
+		inline
+			directory_iterator end(const directory_iterator&) BOOST_NOEXCEPT
+		{
+			return directory_iterator();
+		}
+
+	}  // namespace filesystem
+}
+
 
 // add boost::filesystem into std::experimental::filesystem
 namespace std {

--- a/include/nana/filesystem/filesystem_ext.hpp
+++ b/include/nana/filesystem/filesystem_ext.hpp
@@ -16,6 +16,7 @@
 #define NANA_FILESYSTEM_EXT_HPP
 
 #include <nana/filesystem/filesystem.hpp>
+#include <nana/deploy.hpp>
 
 namespace nana 
 {
@@ -33,6 +34,16 @@ namespace filesystem_ext
 #endif
  
 std::experimental::filesystem::path path_user();    ///< extention ?
+
+													/// workaround Boost not having path.generic_u8string() - a good point for http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0251r0.pdf
+inline std::string generic_u8string(const std::experimental::filesystem::path& p)
+{
+#if NANA_USING_BOOST_FILESYSTEM
+	return nana::to_utf8(p.generic_wstring());
+#else
+	return p.generic_u8string();
+#endif
+}
 
 inline bool is_directory(const std::experimental::filesystem::directory_entry& dir) noexcept
 {


### PR DESCRIPTION
Or just merge your develop or hotfix back to develop-c++17.