### PR TITLE
Checking whether MinGW really supports threads

### DIFF
--- a/include/nana/c++defines.hpp
+++ b/include/nana/c++defines.hpp
@@ -171,9 +171,9 @@
 	#endif
 #endif
 
-//Assume the std::thread is not implement on MinGW
+//Assume the std::thread is not implemented on MinGW,
+//unless it was compiled with POSIX threading support.
 //But some toolchains may implement std::thread.
-// it seems that MinGW 6.3 and 7.1 have std::thread
 #ifdef NANA_MINGW
 #	ifndef STD_THREAD_NOT_SUPPORTED
 #		define STD_THREAD_NOT_SUPPORTED
@@ -221,8 +221,11 @@
 #  if __has_include(<filesystem>)
 #    undef STD_FILESYSTEM_NOT_SUPPORTED
 #  endif
-#  if __has_include(<mutex>)
-#    undef STD_THREAD_NOT_SUPPORTED
+#  if __has_include(<mutex>) 
+#    if !(defined(NANA_MINGW) && !defined(_GLIBCXX_HAS_GTHREADS))
+//See the comment above regarding MinGW's threading support
+#      undef STD_THREAD_NOT_SUPPORTED
+#    endif
 #  endif
 #endif
 


### PR DESCRIPTION
Related to https://github.com/cnjinhao/nana/issues/295, see the detailed description in the issue.

Further investigation revealed that unless the MinGW binary is built with `--enable-threads=posix` - which is not the default - it can't implement threading as we expect in Nana, despite the `mutex` header being present.

I tested the changes with **i686-w64-mingw32-g++**, gcc version 6.3.0 20170516 (GCC), targeting Windows x86 from Linux.