### PR TITLE
fix filebox.init_file()

### DIFF
--- a/source/gui/filebox.cpp
+++ b/source/gui/filebox.cpp
@@ -1041,7 +1041,8 @@ namespace nana
 		bool filebox::show() const
 		{
 #if defined(NANA_WINDOWS)
-			std::wstring wfile;
+			auto winitfile = to_wstring(impl_->file);
+			std::wstring wfile(winitfile);
 			wfile.resize(520);
 
 			OPENFILENAME ofn;


### PR DESCRIPTION
filebox.init_file() is not working on WIN.
This is a possible solution (at least works for me)

Ciao