### PR TITLE
New textbox::getline overload returning an optional<string>

### DIFF
--- a/include/nana/gui/widgets/textbox.hpp
+++ b/include/nana/gui/widgets/textbox.hpp
@@ -17,6 +17,8 @@
 #include "skeletons/textbase_export_interface.hpp"
 #include "skeletons/text_editor_part.hpp"
 
+#include <nana/optional.hpp>
+
 namespace nana
 {
 	class textbox;
@@ -172,6 +174,13 @@ namespace nana
 
 		/// Read the text from a specified line with a set offset. It returns true for success.
 		bool getline(std::size_t line_index,std::size_t offset,std::string& text) const;
+
+		/// Read the text from a specified line; returns an empty optional on failure
+		std::optional<std::string> getline(std::size_t pos) const;
+
+		///Read the text from a specified line with a set offset. Returns an empty optional for
+		/// failure.
+		std::optional<std::string> getline(std::size_t line_index, std::size_t offset) const;
 
 		/// Gets the caret position
 		/// Returns true if the caret is in the area of display, false otherwise.

--- a/source/gui/widgets/textbox.cpp
+++ b/source/gui/widgets/textbox.cpp
@@ -377,6 +377,27 @@ namespace drawerbase {
 			return false;
 		}
 
+		std::optional<std::string> textbox::getline(std::size_t pos) const
+		{
+			auto result = std::string{};
+			if ( getline(pos, result) )
+			{
+				return { std::move(result) };
+			}
+			return {};
+		}
+
+		std::optional<std::string> textbox::getline(std::size_t line_index, std::size_t offset) const
+		{
+			auto result = std::string{};
+			if ( getline(line_index, offset, result) )
+			{
+				return { std::move(result) };
+			}
+			return {};
+		}
+
+
 		/// Gets the caret position
 		bool textbox::caret_pos(point& pos, bool text_coordinate) const
 		{


### PR DESCRIPTION
I've added two new overloads for `textbox::getline`:
```cpp
std::optional<std::string> textbox::getline(std::size_t pos) const;
std::optional<std::string> textbox::getline(std::size_t line_index, std::size_t offset) const;
```
Using `std::optional` the user can have as a result either the string or a failure (the empty state) without need to create a new `std::string` to pass by reference.
