### PR TITLE
Fixed condidtion for defining _nana_std_otpional.

### DIFF
--- a/include/nana/c++defines.hpp
+++ b/include/nana/c++defines.hpp
@@ -212,7 +212,7 @@
 
 #undef _nana_std_optional
 #if ((defined(_MSC_VER) && (_MSC_VER >= 1912) && ((!defined(_MSVC_LANG)) || _MSVC_LANG < 201703))) ||	\
-	((__cplusplus < 201703L) || \
+	((__cplusplus < 201703L) && \
 		(defined(__clang__) && (__clang_major__ * 100 + __clang_minor__ < 400)) ||				\
 		(!defined(__clang__) && defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ < 701))	\
 	)


### PR DESCRIPTION
This is my quick fix regarding #338. I believe this condition was broken but I might be wrong.