### PR TITLE
Add method to check option in group

### DIFF
--- a/include/nana/gui/widgets/group.hpp
+++ b/include/nana/gui/widgets/group.hpp
@@ -74,6 +74,10 @@ namespace nana{
 		group& div(const char* div_str) throw();
 		field_reference operator[](const char* field);
 
+        void field_display(const char* field_name, bool display); ///<Displays/Discards an existing field.
+		bool field_display(const char* field_name) const;	///<Determines whether the specified field is displayed.
+		void erase(window handle);				///< Erases a window from field.
+
 		template<typename Widget, typename ...Args>
 		Widget* create_child(const char* field, Args && ... args)
 		{

--- a/include/nana/gui/widgets/group.hpp
+++ b/include/nana/gui/widgets/group.hpp
@@ -3,8 +3,8 @@
  *	Nana C++ Library(http://www.nanaro.org)
  *	Copyright(C) 2015 Jinhao(cnjinhao@hotmail.com)
  *
- *	Distributed under the Boost Software License, Version 1.0. 
- *	(See accompanying file LICENSE_1_0.txt or copy at 
+ *	Distributed under the Boost Software License, Version 1.0.
+ *	(See accompanying file LICENSE_1_0.txt or copy at
  *	http://www.boost.org/LICENSE_1_0.txt)
  *
  *	@file: nana/gui/widgets/group.hpp
@@ -55,8 +55,15 @@ namespace nana{
 		/// Enables/disables the radio mode which is single selection
 		group& radio_mode(bool);
 
-		/// Returns the index of option in radio_mode, it throws a logic_error if radio_mode is false.
+		/// Returns the index of selected option in radio_mode, it throws a logic_error if radio_mode is false.
 		std::size_t option() const;
+
+        /** Set check/unchecked status of specified option
+            @param[in] pos zero-based index of option to set
+            @param[in] check status required, defaults to checked
+            throws an out_of_range if !(pos < number of options)
+        */
+        void option_check( std::size_t pos, bool check = true );
 
 		/// Determines whether a specified option is checked, it throws an out_of_range if !(pos < number of options)
 		bool option_checked(std::size_t pos) const;
@@ -66,7 +73,7 @@ namespace nana{
 		group& collocate() throw();
 		group& div(const char* div_str) throw();
 		field_reference operator[](const char* field);
-		
+
 		template<typename Widget, typename ...Args>
 		Widget* create_child(const char* field, Args && ... args)
 		{

--- a/source/gui/widgets/group.cpp
+++ b/source/gui/widgets/group.cpp
@@ -3,8 +3,8 @@
  *	Nana C++ Library(http://www.nanaro.org)
  *	Copyright(C) 2015-2017 Jinhao(cnjinhao@hotmail.com)
  *
- *	Distributed under the Boost Software License, Version 1.0. 
- *	(See accompanying file LICENSE_1_0.txt or copy at 
+ *	Distributed under the Boost Software License, Version 1.0.
+ *	(See accompanying file LICENSE_1_0.txt or copy at
  *	http://www.boost.org/LICENSE_1_0.txt)
  *
  *	@file: nana/gui/widgets/group.cpp
@@ -14,7 +14,7 @@
  *	@brief group is a widget used to visually group and layout other widgets.
  *
  * 	@contributor:
- *		dankan1890(https://github.com/dankan1890) 
+ *		dankan1890(https://github.com/dankan1890)
  */
 
 
@@ -159,6 +159,12 @@ namespace nana{
 
 		throw std::logic_error("the radio_mode of the group is disabled");
 	}
+
+    void group::option_check( std::size_t pos, bool check )
+    {
+ 		_THROW_IF_EMPTY();
+		return impl_->options.at(pos)->check( check );
+    }
 
 	bool group::option_checked(std::size_t pos) const
 	{


### PR DESCRIPTION
The group widget has a method to get the checked status an option in the group.  However, there is no method to set the checked status.  This is needed when an application starts up so that it can set default values, or values from an pre-existing database that is to be edited.