### PR TITLE
OFN_FILEMUSTEXIST for filebox in open mode (Windows)

### DIFF
--- a/source/gui/filebox.cpp
+++ b/source/gui/filebox.cpp
@@ -1494,6 +1494,7 @@ namespace nana
 
 		if (!impl_->open_or_save)
 			ofn.Flags = OFN_OVERWRITEPROMPT;	//Overwrite prompt if it is save mode
+		else ofn.Flags = OFN_FILEMUSTEXIST;	//In open mode, user can't type name of nonexistent file
 		ofn.Flags |= OFN_NOCHANGEDIR;
 		if(impl_->allow_multi_select)
 		{


### PR DESCRIPTION
When the user types in the name of a nonexistent file, or selects a file and then changes the folder, the OFN_FILEMUSTEXIST flag causes the dialog box to pop up a warning message box when the user clicks the "Open" button, instead of closing and returning a nonexistent path.