### PR TITLE
fixes #401 pkg config file is now installed when target 'install' is built

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,9 @@
 #  It seems that project() defines essential system variables like CMAKE_FIND_LIBRARY_PREFIXES.
 #  https://bbs.archlinux.org/viewtopic.php?id=84967
 
-project(nana)
 cmake_minimum_required(VERSION 2.8)
+cmake_policy(SET CMP0048 NEW)
+project("nana" VERSION 1.6.2)
 
 option(NANA_CMAKE_INSTALL_INCLUDES "Install nana includes when compile the library" ON)
 option(NANA_CMAKE_ENABLE_MINGW_STD_THREADS_WITH_MEGANZ "replaced boost.thread with meganz's mingw-std-threads." OFF)
@@ -353,6 +354,7 @@ if(NANA_CMAKE_INSTALL_INCLUDES)
     message("The Nana include files will be installed in ${CMAKE_INSTALL_PREFIX}/include")
 endif()
 
+add_subdirectory("pkg_config")
 
 # Just for information:
 message ("")

--- a/pkg_config/CMakeLists.txt
+++ b/pkg_config/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(PKGCONFIG_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/share/pkgconfig" CACHE PATH "Installation directory for pkgconfig (.pc) files")
+
+set(NANA_PKGCONFIG ${CMAKE_CURRENT_BINARY_DIR}/nana.pc)
+
+CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/nana.pc.in "${NANA_PKGCONFIG}" @ONLY)
+
+install(FILES "${NANA_PKGCONFIG}" DESTINATION "${PKGCONFIG_INSTALL_DIR}")

--- a/pkg_config/nana.pc.in
+++ b/pkg_config/nana.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${exec_prefix}/include
+
+Name: nana
+Description: An opensource cross-platform GUI library written in modern C++11 for static linking
+Version: @PROJECT_VERSION@
+Libs: -L${libdir} @NANA_LINKS@
+Cflags: -I${includedir}


### PR DESCRIPTION
Allows package managers to correctly pick up nana library.