### PR TITLE
Added internationalization loading option with ifstream 

### DIFF
--- a/include/nana/internationalization.hpp
+++ b/include/nana/internationalization.hpp
@@ -30,6 +30,9 @@ namespace nana
 		void load(const std::string& file);
 		void load_utf8(const std::string& file);
 
+		void load(std::ifstream& inputFileStream);
+		void load_utf8(std::ifstream& inputFileStream);
+
 		template<typename ...Args>
 		::std::string get(std::string msgid_utf8, Args&&... args) const
 		{


### PR DESCRIPTION
Added internationalization loading option with ifstream instead of only string filename. Opens support for various usages - one of which being wstring paths on Windows.