### PR TITLE
timer compatible with std::chrono

### DIFF
--- a/include/nana/gui/timer.hpp
+++ b/include/nana/gui/timer.hpp
@@ -53,7 +53,17 @@ namespace nana
 		void stop();
 
 		void interval(unsigned milliseconds);   ///< Set the duration between calls (millisec ??)
+		template <typename Rep, typename Period>
+		inline void interval(std::chrono::duration<Rep, Period> const & time_interval) ///< Set the duration between calls, accepts std::chrono
+		{
+		    interval(std::chrono::duration_cast<std::chrono::milliseconds>(time_interval).count());
+		}
 		unsigned interval() const;
+		template <typename Duration = std::chrono::milliseconds>
+		inline Duration interval() const
+		{
+		    return std::chrono::duration_cast<Duration>(std::chrono::milliseconds(interval));
+		}
 	private:
 		nana::basic_event<arg_elapse> elapse_;
 		implement * const impl_;

--- a/include/nana/gui/timer.hpp
+++ b/include/nana/gui/timer.hpp
@@ -38,6 +38,9 @@ namespace nana
 		timer& operator=(timer&&) = delete;
 	public:
 		timer();
+		timer(unsigned int ms) : timer{} { interval(ms); } /// Accepts an initial interval in ms
+		template <typename Rep, typename Period> /// Accepts an initial interval in any chrono unit
+		explicit timer(std::chrono::duration<Rep, Period> const & time) : timer{} { interval(time); }
 
 		~timer();
 


### PR DESCRIPTION
* Now is possible to construct a timer with an `unsigned int` or any `std::chrono::duration` like `std::chrono::milliseconds`.
* Added an overload `timer::interval(Duration)` compatible with chrono types:
```cpp
my_timer.interval(std::chrono::milliseconds{25});
my_timer.interval(5s);
```
* Added a templated overload `timer::interval<Duration>()` to get directly chrono types:
```cpp
auto interval = my_timer.interval<std::chrono::microseconds>();
```

I've added the constructor with `unsigned` for consistency with the `interval` function, which accepts an `unsigned int` too, but maybe it would be better to remove all the `unsigned` functions (they are ambiguous about the time unit)?