### PR TITLE
deprecated use of unsigned overloadings for functions in class timer

### DIFF
--- a/include/nana/gui/timer.hpp
+++ b/include/nana/gui/timer.hpp
@@ -38,7 +38,9 @@ namespace nana
 		timer& operator=(timer&&) = delete;
 	public:
 		timer();
-		timer(unsigned int ms) : timer{} { interval(ms); } /// Accepts an initial interval in ms
+		[[deprecated("prefer a std::chrono::duration (like std::chrono::milliseconds) over "
+			     "raw integers for durations")]]
+		timer(unsigned int ms) : timer{} { interval_(ms); } /// Accepts an initial interval in ms
 		template <typename Rep, typename Period> /// Accepts an initial interval in any chrono unit
 		explicit timer(std::chrono::duration<Rep, Period> const & time) : timer{} { interval(time); }
 
@@ -55,11 +57,13 @@ namespace nana
 		bool started() const;
 		void stop();
 
-		void interval(unsigned milliseconds);   ///< Set the duration between calls (millisec ??)
+		[[deprecated("prefer a std::chrono::duration (like std::chrono::milliseconds) over "
+			     "raw integers for durations")]]
+		inline void interval(unsigned milliseconds) { interval_(milliseconds); }
 		template <typename Rep, typename Period>
 		inline void interval(std::chrono::duration<Rep, Period> const & time_interval) ///< Set the duration between calls, accepts std::chrono
 		{
-		    interval(std::chrono::duration_cast<std::chrono::milliseconds>(time_interval).count());
+		    interval_(std::chrono::duration_cast<std::chrono::milliseconds>(time_interval).count());
 		}
 		unsigned interval() const;
 		template <typename Duration = std::chrono::milliseconds>
@@ -67,6 +71,8 @@ namespace nana
 		{
 		    return std::chrono::duration_cast<Duration>(std::chrono::milliseconds(interval));
 		}
+	private:
+		void interval_(unsigned milliseconds);   ///< Set the duration between calls (millisec ??)
 	private:
 		nana::basic_event<arg_elapse> elapse_;
 		implement * const impl_;

--- a/source/gui/timer.cpp
+++ b/source/gui/timer.cpp
@@ -220,7 +220,7 @@ namespace nana
 			timer_driver::instance().destroy(tmid);
 		}
 
-		void timer::interval(unsigned ms)
+		void timer::interval_(unsigned ms)
 		{
 			if (ms != impl_->interval)
 			{


### PR DESCRIPTION
Deprecated use of `unsigned` overloadings for `timer::timer` and `timer::interval`: as mentioned in #416 `std::chrono::duration`s should be preferred over `unsigned int`s to represent time intervals.
I preferred to deprecate the features instead of removing them (as proposed in #416) as this would have led to breaking changes.

(I didn't have deprecated `unsigned timer::interval() const`; I can do it if needed)