### PR TITLE
c++ runtime static linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,27 +54,25 @@ target_compile_features(nana
 # in your own CMakeLists.txt, and them :
 # target_link_libraries(yourApp PRIVATE nana )
 
-set(NANA_SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/source)
-
-set(NANA_SOURCE_SUBDIRS
-        /.
-        /detail
-        /detail/posix
-        /filesystem
-        /gui
-        /gui/detail
-        /gui/widgets
-        /gui/widgets/skeletons
-        /paint
-        /paint/detail
-        /system
-        /threads
-        )
+set(NANA_SOURCE_DIR         ${CMAKE_CURRENT_LIST_DIR}/source)
+set(NANA_SOURCE_SUBDIRS     /.
+                            /detail
+                            /detail/posix
+                            /filesystem
+                            /gui
+                            /gui/detail
+                            /gui/widgets
+                            /gui/widgets/skeletons
+                            /paint
+                            /paint/detail
+                            /system
+                            /threads
+                            )
 if(NANA_CMAKE_ENABLE_AUDIO)
     list(APPEND NANA_SOURCE_SUBDIRS
-            /audio
-            /audio/detail
-            )
+                            /audio
+                            /audio/detail
+                            )
 endif()
 
 # collect all source files in the source-sub-dir
@@ -87,26 +85,24 @@ target_sources(nana PRIVATE ${SOURCES})
 ###    collect all headers sub-directories in a list to avoid duplication   ###
 # To show .h files in Visual Studio, add them to the list of sources in add_executable / add_library / target_sources
 # and Use SOURCE_GROUP if all your sources are in the same directory
-set(NANA_INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/include)
-
-set(NANA_INCLUDE_SUBDIRS
-        /.
-        /filesystem
-        /gui
-        /gui/detail
-        /gui/widgets
-        /gui/widgets/skeletons
-        /paint
-        /paint/detail
-        /pat
-        /system
-        /threads
-        )
+set(NANA_INCLUDE_DIR        ${CMAKE_CURRENT_LIST_DIR}/include)
+set(NANA_INCLUDE_SUBDIRS    /.
+                            /filesystem
+                            /gui
+                            /gui/detail
+                            /gui/widgets
+                            /gui/widgets/skeletons
+                            /paint
+                            /paint/detail
+                            /pat
+                            /system
+                            /threads
+                            )
 if(NANA_CMAKE_ENABLE_AUDIO)
     list(APPEND NANA_INCLUDE_SUBDIRS
-            /audio
-            /audio/detail
-            )
+                            /audio
+                            /audio/detail
+                            )
 endif()
 
 foreach(subdir ${NANA_INCLUDE_SUBDIRS})

--- a/build/cmake/select_filesystem.cmake
+++ b/build/cmake/select_filesystem.cmake
@@ -1,11 +1,12 @@
-# The ISO C++ File System Technical Specification (ISO-TS, or STD) is optional.
+# The ISO C++ File System Technical Specification (ISO-TS, or STD) was optional.
 #              http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4100.pdf
-# This is not a workaround, but an user option.
-# The library maybe available in the std library in use or from Boost (almost compatible)
+# It is part of c++17.
+# The library may be not available or working correctly in the std library in use. As a workaround we may try
+# to "implement" it (ab)using Boost (almost compatible)
 #              http://www.boost.org/doc/libs/1_60_0/libs/filesystem/doc/index.htm
 # or you can choose to use the (partial, but functional) implementation provided by nana.
 # If you include the file <nana/filesystem/filesystem.hpp> or <nana/filesystem/filesystem_ext.hpp>
-# the selected option will be set by nana into std::experimental::filesystem
+# the selected option will be set by nana into std::filesystem
 # By default Nana will try to use the STD. If STD is not available and NANA_CMAKE_FIND_BOOST_FILESYSTEM
 # is set to ON nana will try to use boost if available. Nana own implementation will be use if none of
 # the previus were selected or available.

--- a/build/cmake/shared_libs.cmake
+++ b/build/cmake/shared_libs.cmake
@@ -40,12 +40,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang") #  AN
     if(BUILD_SHARED_LIBS)
         target_compile_options(nana PUBLIC  -lgcc -lstdc++)
     else()
-
-        if(MINGW)
-            target_compile_options(nana PUBLIC -static)     #  -static ?? cmake knows BUILD_SHARED_LIBS
-        else()
-            target_compile_options(nana PUBLIC -static-libgcc -static-libstdc++)
-        endif()
+        target_compile_options(nana PUBLIC -static -static-libstdc++)
     endif(BUILD_SHARED_LIBS)
 
 endif()

--- a/build/cmake/shared_libs.cmake
+++ b/build/cmake/shared_libs.cmake
@@ -40,7 +40,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang") #  AN
     if(BUILD_SHARED_LIBS)
         target_compile_options(nana PUBLIC  -lgcc -lstdc++)
     else()
-        target_compile_options(nana PUBLIC -static -static-libstdc++)
+        target_link_libraries(nana PUBLIC -static -static-libstdc++)
     endif(BUILD_SHARED_LIBS)
 
 endif()


### PR DESCRIPTION
This prevent the need to copy some dll with some MinGW distribution.
Tested with gcc 9.1.1, the lastest optionfrom https://gcc-mcf.lhmouse.com/
 
It set: CMAKE_CXX_COMPILER_VERSION = 9.1.1 !!!

I changed the build/cmake/compilers.cmake to add static c++ runtime linking but still need to copy mcfgthread-12.dll with the .exe files.
How to fix that? I want all static linked, and move around just my .exe file