### PR TITLE
add alias nana::nana in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ project(nana VERSION      1.6.2
 #######################     Main setting of Nana targets, sources and installs    #####################
 
 add_library(nana)
+add_library(nana::nana ALIAS nana)
 target_compile_features(nana PUBLIC cxx_std_17)
 
 #  need after cxx_std_14 or cxx_std_17 ??


### PR DESCRIPTION
This commit adds the alias to allow the use of nana::nana in other projects as per guideline https://gist.github.com/mbinna/c61dbb39bca0e4fb7d1f73b0d66a4fd1#using-a-library-defined-in-the-same-cmake-tree-should-look-the-same-as-using-an-external-library.

This change should not break anything, it only adds an alternative name