### PR TITLE
Stopped linking stdc++fs on windows

### DIFF
--- a/build/cmake/select_filesystem.cmake
+++ b/build/cmake/select_filesystem.cmake
@@ -21,7 +21,9 @@ if(NANA_CMAKE_NANA_FILESYSTEM_FORCE)
 
 elseif(NANA_CMAKE_STD_FILESYSTEM_FORCE)
     target_compile_definitions(nana PUBLIC STD_FILESYSTEM_FORCE)
-    target_link_libraries     (nana PUBLIC stdc++fs)
+	if (CMAKE_CXX_COMPILER_ID STREQUAL GNU)
+		target_link_libraries     (nana PUBLIC stdc++fs)
+	endif()
 
 elseif(NANA_CMAKE_BOOST_FILESYSTEM_FORCE)
     target_compile_definitions(nana PUBLIC BOOST_FILESYSTEM_FORCE)
@@ -43,7 +45,9 @@ elseif(NANA_CMAKE_BOOST_FILESYSTEM_FORCE)
 
 else()
     # todo   test for std    (for now just force nana or boost if there no std)
-    target_link_libraries     (nana PUBLIC stdc++fs)
+	if (CMAKE_CXX_COMPILER_ID STREQUAL GNU)
+		target_link_libraries     (nana PUBLIC stdc++fs)
+	endif()
 
     # todo if not test for boost
     # if not add nana filesystem

--- a/build/cmake/select_filesystem.cmake
+++ b/build/cmake/select_filesystem.cmake
@@ -21,7 +21,7 @@ if(NANA_CMAKE_NANA_FILESYSTEM_FORCE)
 
 elseif(NANA_CMAKE_STD_FILESYSTEM_FORCE)
     target_compile_definitions(nana PUBLIC STD_FILESYSTEM_FORCE)
-	if (CMAKE_CXX_COMPILER_ID STREQUAL GNU)
+	if (NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)
 		target_link_libraries     (nana PUBLIC stdc++fs)
 	endif()
 
@@ -45,15 +45,11 @@ elseif(NANA_CMAKE_BOOST_FILESYSTEM_FORCE)
 
 else()
     # todo   test for std    (for now just force nana or boost if there no std)
-	if (CMAKE_CXX_COMPILER_ID STREQUAL GNU)
+	if (NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)
 		target_link_libraries     (nana PUBLIC stdc++fs)
 	endif()
 
     # todo if not test for boost
     # if not add nana filesystem
 endif()
-
-
-
-
 


### PR DESCRIPTION
Please refer to #423 for more details.  
Added conditions in `select_filesystem.cmake` code so that when building on Windows `stdc++fs` is not being passed to linker.