### PR TITLE
fixed another listbox selection bug

### DIFF
--- a/source/gui/widgets/listbox.cpp
+++ b/source/gui/widgets/listbox.cpp
@@ -4334,7 +4334,7 @@ namespace nana
 									else
 									{
 										auto selected = lister.pick_items(true);
-										if (selected.cend() != std::find(selected.cbegin(), selected.cend(), item_pos))
+										if (selected.cend() != std::find(selected.cbegin(), selected.cend(), abs_item_pos))
 										{
 											//If the current selected one has been selected before selecting, remains the selection states for all
 											//selected items. But these items will be unselected when the mouse is released.


### PR DESCRIPTION
Items don't always deselect correctly during the `mouse_down` event, because a display position is searched for in a set of absolute positions.

To test the effect this has, run the code below, and click the items "fourth absolute" and "second absolute" in that order.

````
#include <nana/gui.hpp>
#include <nana/gui/widgets/listbox.hpp>

int main()
{
	nana::form fm{nana::API::make_center(234, 234)};
	fm.div("vert margin=15 <listbox>");

	nana::listbox lb{fm};
	fm["listbox"] << lb;
	lb.append_header("Col 0");
	lb.at(0).append("first absolute");
	lb.at(0).append("second absolute");
	lb.at(0).append("third absolute");
	lb.at(0).append("fourth absolute");
	lb.at(0).append("fifth absolute");
	lb.column_at(0).fit_content();
	lb.sort_col(0);

	fm.collocate();
	fm.show();
	nana::exec();
}
````