### PR TITLE
Fixed issue on dockpane close

### DIFF
--- a/source/gui/place_parts.hpp
+++ b/source/gui/place_parts.hpp
@@ -126,6 +126,12 @@ namespace nana
 			{
 				close_fn_ = std::move(fn);
 			}
+
+			bool hit_close()
+			{
+				return x_pointed_;
+			}
+
 		private:
 			virtual void attached(widget_reference wdg, graph_reference graph) override
 			{
@@ -310,7 +316,9 @@ namespace nana
 							{
 								move_pos += moves_.start_container_pos;
 								API::move_window(container_->handle(), move_pos);
-								notifier_->notify_move();
+
+								if(!caption_.get_drawer_trigger().hit_close())
+									notifier_->notify_move();
 							}
 						}
 					}


### PR DESCRIPTION
Now closing a dockpane when the x button is inside the place area don't show the dock indicator anymore.