### PR TITLE
platform_runtime - fixed static initialization bug

### DIFF
--- a/source/detail/platform_abstraction.hpp
+++ b/source/detail/platform_abstraction.hpp
@@ -22,6 +22,8 @@
 namespace nana
 {
 
+	struct platform_runtime;
+	platform_runtime& platform_runtime_instance();
 
 	class platform_abstraction
 	{
@@ -30,9 +32,6 @@ namespace nana
 
 		using path_type = ::std::filesystem::path;
 
-		static void initialize();
-		/// Shutdown before destruction of platform_spec 
-		static void shutdown();
 		static double font_default_pt();
 		static void font_languages(const std::string&);
 		static ::std::shared_ptr<font> default_font(const ::std::shared_ptr<font>&);

--- a/source/detail/platform_spec_windows.cpp
+++ b/source/detail/platform_spec_windows.cpp
@@ -114,12 +114,11 @@ namespace detail
 	platform_spec::platform_spec()
 		: impl_{ new implementation}
 	{
-		platform_abstraction::initialize();
+		platform_runtime_instance(); // force initialization
 	}
 
 	platform_spec::~platform_spec()
 	{
-		platform_abstraction::shutdown();
 		delete impl_;
 	}
 


### PR DESCRIPTION
platform_runtime was not guuaranteed to be initialized. Changed
implementation to Meyer's singleton. Any other file which needs
platform_runtime must include platform_abstraction.hpp and use
platform_runtime_instance(). Calling the function will prevent
the linker from delaying or removing initialization.