### PR TITLE
FIX reversion in static linking introduced in #469

### DIFF
--- a/build/cmake/shared_libs.cmake
+++ b/build/cmake/shared_libs.cmake
@@ -37,7 +37,7 @@ if(BUILD_SHARED_LIBS)   # todo test
 endif()
 
 if(NANA_STATIC_STDLIB)
-    target_compile_options(nana
+    target_link_libraries(nana
         PUBLIC $<$<OR:$<CXX_COMPILER_ID:GNU>, $<CXX_COMPILER_ID:Clang>>: -static-libgcc -static-libstdc++>)
 endif()
 


### PR DESCRIPTION
#469 is broken: don't link statically all lib.
Now tested OK using cmake/mingw-w64-gcc-mcf_20190705_9.1.1_x86/windows10
(still need to "install" mcfgthread-12.dll, but only that one)