### PR TITLE
Fixing incorrect buffer in WideCharToMultiByte call in wc2mb (charset.cpp)

### DIFF
--- a/source/charset.cpp
+++ b/source/charset.cpp
@@ -246,7 +246,7 @@ namespace nana
 			if(bytes > 1)
 			{
 				mbstr.resize(bytes - 1);
-				::WideCharToMultiByte(CP_ACP, 0, s, -1, &(mbstr[0]), bytes - 1, 0, 0);
+				::WideCharToMultiByte(CP_ACP, 0, s, -1, &(mbstr[0]), bytes, 0, 0);
 			}
 			return true;
 #else

--- a/source/charset.cpp
+++ b/source/charset.cpp
@@ -280,7 +280,7 @@ namespace nana
 			if(chars > 1)
 			{
 				wcstr.resize(chars - 1);
-				::MultiByteToWideChar(CP_ACP, 0, s, -1, &wcstr[0], chars - 1);
+				::MultiByteToWideChar(CP_ACP, 0, s, -1, &wcstr[0], chars);
 			}
 #else
 			locale_initializer::init();


### PR DESCRIPTION
I noticed that `form.icon()` did not work properly under MinGW - long story short, turns out that the [WideCharToMultiByte](https://docs.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-widechartomultibyte) call got an incorrect `cbMultiByte` parameter - thus returned an `ERROR_INSUFFICIENT_BUFFER` error.

- `mbstr.resize(bytes - 1);` is correct - that is counted *without* the terminating zero.
- `cbMultiByte`, however is _"Size, in bytes, of the buffer indicated by lpMultiByteStr."_ so the terminating zero must be counted too.

I am not sure how to proceed with adding checks for all return values of all of the `Stringapiset.h` calls here, so I'll leave that for later. Ideally `wc2mb` should have failed though.