### PR TITLE
Fix inconsistency regarding filebox multi_select

### DIFF
--- a/source/gui/filebox.cpp
+++ b/source/gui/filebox.cpp
@@ -1516,14 +1516,24 @@ namespace nana
 
 			path_type parent_path{ str };
 			str += (len + 1);
-
-			while(*str)
+			
+			// if only one file was selected, the ofn.lpstrFile
+			// is returning only that file, without any parent
+			if (!*str)
 			{
-				len = ::wcslen(str);
-				targets.emplace_back(parent_path / path_type{str});
-				str += (len + 1);
+				targets.emplace_back(parent_path);
+				impl_->path = parent_path.parent_path().u8string();
 			}
-			impl_->path = parent_path.u8string();
+			else
+			{
+				while(*str)
+				{
+					len = ::wcslen(str);
+					targets.emplace_back(parent_path / path_type{str});
+					str += (len + 1);
+				}
+				impl_->path = parent_path.u8string();
+			}
 		}
 		else
 		{


### PR DESCRIPTION
When only one file is selected, the `lpstrFile` variable contains only the path to that file, without the parent path before that, thus, the `targets` vector is empty and the `path` variable contains the actual path to the file. This is inconsistent with the scenario where multiple files are selected, in which `targets` contains the file paths and `path` contains the parent directory path.