### PR TITLE
Bug fixes for listbox, treebox, and nana::any

### DIFF
--- a/include/nana/any.hpp
+++ b/include/nana/any.hpp
@@ -74,7 +74,7 @@ namespace nana
 		any(Value && value,
 				typename std::enable_if<!std::is_same<any&, Value>::value>::type * = nullptr,
 				typename std::enable_if<!std::is_const<Value>::value>::type* = nullptr)
-			: content_(new holder<typename std::decay<Value>::type>(static_cast<Value&&>(value)))
+			: content_(new holder<typename std::decay<Value>::type>(std::forward<Value>(value)))
 		{
 		}
 
@@ -87,7 +87,7 @@ namespace nana
 		template<class Value>
 		any& operator=(Value&& other)
 		{
-			any(other).swap(*this);
+			any(std::forward<Value>(other)).swap(*this);
 			return *this;
 		}
 

--- a/source/gui/widgets/listbox.cpp
+++ b/source/gui/widgets/listbox.cpp
@@ -5949,6 +5949,7 @@ namespace nana
 		{
 			internal_scope_guard lock;
 			_m_ess().lister.sort_column(col, &reverse);
+			_m_ess().update();
 		}
 
 		auto listbox::sort_col() const -> size_type

--- a/source/gui/widgets/listbox.cpp
+++ b/source/gui/widgets/listbox.cpp
@@ -2387,7 +2387,9 @@ namespace nana
 								nana::rectangle r;
 								if (rect_lister(r))
 								{
-									auto top = new_where.second * item_h + header_visible_px();
+									//potential displacement due to partially visible first visible item
+									auto disp = origin.y - first_display().item * item_h;
+									auto top = new_where.second * item_h + header_visible_px() - disp;
 									if (checkarea(item_xpos(r), static_cast<int>(top)).is_hit(pos))
 										new_where.first = parts::checker;
 								}

--- a/source/gui/widgets/treebox.cpp
+++ b/source/gui/widgets/treebox.cpp
@@ -1274,7 +1274,10 @@ namespace nana
 
 				item_proxy	item_proxy::operator++(int)
 				{
-					return sibling();
+					item_proxy ip(*this);
+					if(trigger_ && node_)
+						node_ = node_->next;
+					return ip;
 				}
 
 				item_proxy& item_proxy::operator*()

--- a/source/gui/widgets/treebox.cpp
+++ b/source/gui/widgets/treebox.cpp
@@ -1952,7 +1952,7 @@ namespace nana
 					impl_->attr.tree_cont.for_each<item_locator&>(shape.first, nl);
 
 					auto const node = nl.node();
-					if (!node)
+					if (!node || !node->child)
 						return;
 
 					switch (nl.what())


### PR DESCRIPTION
- `treebox.cpp`:  fixed a bug in `trigger::dbl_click()`
`impl_->set_expanded()` was called unconditionally, even if the node had no children. This caused the node icon to change to the "expanded" icon if the node had an icon scheme, even when the node didn't have children.
- `listbox.cpp`:  `listbox::sort_col` doesn't update view
Calling `listbox::sort_col` to change the sort column doesn't update the viewport to reflect the change, forcing the user to call `API::refresh_window` or otherwise perform stupid tricks to force the listbox to refresh.
- `any.hpp`: argument not forwarded
A constructor and an overload of the assignment operator each have a forwarding reference as a parameter, but they don't actually forward the argument.
- `treebox.cpp`:  fixed buggy `item_proxy` postfix increment operator
The behavior of the postfix increment operator is not consistent with the increment operator concept (currently just returns the next sibling node).
- `listbox.cpp`: `nana::drawerbase::listbox::essence::where` incorrectly calculates the position of checkboxes in the listbox content area (see the extensive description in the commit)