### PR TITLE
Fix tabbar drawing not updated when a tab is erased

### DIFF
--- a/source/gui/widgets/tabbar.cpp
+++ b/source/gui/widgets/tabbar.cpp
@@ -1229,7 +1229,8 @@ namespace nana
 
 				void trigger::erase(std::size_t pos)
 				{
-					layouter_->erase(pos);
+					if (layouter_->erase(pos))
+						API::refresh_window(layouter_->widget_handle());
 				}
 
 				void trigger::tab_color(std::size_t i, bool is_bgcolor, const ::nana::color& clr)


### PR DESCRIPTION
When a tab is deleted using `tabbar::erase`, `trigger::erase` is called. This function does not call `API::refresh_window` if the tab was erased successfully (unlike `trigger::tab_color`, `trigger::tab_image`, etc.), thus the tab is still visible until an interaction is made (like mouse click on `tabbar`).