### PR TITLE
fix static stdlib generator expression

### DIFF
--- a/build/cmake/shared_libs.cmake
+++ b/build/cmake/shared_libs.cmake
@@ -38,6 +38,9 @@ endif()
 
 if(NANA_STATIC_STDLIB)
     target_link_libraries(nana
-        PUBLIC $<$<OR:$<CXX_COMPILER_ID:GNU>, $<CXX_COMPILER_ID:Clang>>: -static-libgcc -static-libstdc++>)
+        PUBLIC
+            $<$<CXX_COMPILER_ID:GNU>:-static-libgcc>
+            $<$<CXX_COMPILER_ID:Clang>:-static-libstdc++>
+            )
 endif()
 


### PR DESCRIPTION
The OR syntax doesn't work.

```
[100%] Linking CXX shared library libnana.so
c++: error: $<$<OR:$: No such file or directory
c++: error: unrecognized command line option ‘-static-libstdc++>’; did you mean ‘-static-libstdc++’?
CMakeFiles/nana.dir/build.make:1260: recipe for target 'libnana.so' failed
make[2]: *** [libnana.so] Error 1
CMakeFiles/Makefile2:75: recipe for target 'CMakeFiles/nana.dir/all' failed
make[1]: *** [CMakeFiles/nana.dir/all] Error 2
Makefile:129: recipe for target 'all' failed
make: *** [all] Error 2
```

Only one COMPILER_ID can be true at any one time. The rest will evaluate to nothing.