### PR TITLE
fix: submenu option items unresponsive to clicks

### DIFF
--- a/source/gui/widgets/menu.cpp
+++ b/source/gui/widgets/menu.cpp
@@ -921,7 +921,25 @@ namespace nana
 					}
 					else if (checks::option == item.style)
 					{
-						get_drawer_trigger().mbuilder().checked(active, true);
+						if(active > 0)
+						{
+							do {
+								if(menu->items[--active]->flags.splitter)
+								{
+									++active;
+									break;
+								}
+							} while(active > 0);
+						}
+						while(active < menu->items.size())
+						{
+							menu_item_type &el = *(menu->items[active++]);
+							if(el.flags.splitter)
+								break;
+							if(checks::option == el.style)
+								el.flags.checked = false;
+						}
+						item.flags.checked = true;
 					}
 
 					this->_m_close_all();	//means deleting this;


### PR DESCRIPTION
When the user opens a submenu containing items with the style `menu::checks::option` and clicks an option, the radio button logic doesn't work. This bug was discovered and fixed by nanapro.org forum user "huycan" (I'm just submitting the PR). See this forum thread: http://nanapro.org/en-us/forum/index.php?u=/topic/1256/ggleave-a-menu-open

As mentioned in more detail in the forum thread linked above, my understanding of why this happens is that `menu_builder::checked` fails because the `menu_window` of the submenu is created with the `menu_builder` object used by the parent menu.