### PR TITLE
Include<stdexcept> in datetime.cpp

### DIFF
--- a/source/datetime.cpp
+++ b/source/datetime.cpp
@@ -15,7 +15,7 @@
 	#include <windows.h>
 #endif
 #include <array>
-#include <ostream>
+#include <stdexcept>
 
 namespace {
 	std::tm localtime()

--- a/source/datetime.cpp
+++ b/source/datetime.cpp
@@ -15,6 +15,7 @@
 	#include <windows.h>
 #endif
 #include <array>
+#include <ostream>
 
 namespace {
 	std::tm localtime()


### PR DESCRIPTION
In a future version of MSVC, <string> doesn't transitively include<ostream>.
This port will compile failed with datetime.cpp(26): error C2039: 'runtime_error': is not a member of 'std'