### PR TITLE
Added option to enable nana config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,10 +114,13 @@ endforeach()
 ###  Some nana compilation options   ###
 option(NANA_CMAKE_AUTOMATIC_GUI_TESTING "Activate automatic GUI testing?" OFF)
 option(NANA_CMAKE_ENABLE_MINGW_STD_THREADS_WITH_MEGANZ "replaced boost.thread with meganz's mingw-std-threads." OFF) # deprecate?
+option(NANA_CMAKE_ENABLE_CONF "enable config.hpp" OFF)
 
 ######## Nana options
 
-target_compile_definitions(nana PRIVATE NANA_IGNORE_CONF)    # really ??
+if(NOT NANA_CMAKE_ENABLE_CONF)
+    target_compile_definitions(nana PRIVATE NANA_IGNORE_CONF)    # really ??
+endif()
 if(NANA_CMAKE_AUTOMATIC_GUI_TESTING)
     target_compile_definitions(nana PUBLIC NANA_AUTOMATIC_GUI_TESTING)
     # todo: enable_testing()       #  ??


### PR DESCRIPTION
I've added option to enable nana config. That was the only way to actually use config.hpp in order to benefit from nana precompiled extrlib AND keep building the whole thing via cmake.

Additional points:
1. Usage of libpng from OS almost always implies usage of the **release build** of libpng.  Which can lead to unexpected crashes as this one
https://stackoverflow.com/questions/22774265/libpng-crashes-on-png-read-info
I have experienced this one myself.

2. I've added extrlib folders as cmake projects which allows me to
    - move them outside of the nana folder and use without any further changes in neither nana's cmake nor config and even the resulting project
    - use the debug version of libpng in the debug build of my project

I'll put my code sample here. It can be placed in the wiki as example for self-implementing or actually included in the nana/extrlib packages.

```cmake
cmake_minimum_required(VERSION 3.5)

project(png)

add_library(png INTERFACE)

get_filename_component(debug_lib libpng.MDd.x64.lib ABSOLUTE)
get_filename_component(release_lib libpng.MD.x64.lib ABSOLUTE)
target_link_libraries(png INTERFACE
    debug ${debug_lib} zlib
    optimized ${release_lib} zlib)
target_include_directories(png INTERFACE .)
target_link_options(png INTERFACE "/ignore:4099")
```
3. I want to discuss the necessity of the difference between 
**enable_png.cmake**  with `target_link_libraries(nana PUBLIC png)`
and **enable_jpeg.cmake** with `target_compile_definitions(nana PUBLIC -ljpeg)`
and possibly change latter to `target_link_libraries(nana PUBLIC jpeg)`