### PR TITLE
fix unknown CMake command check_include_file_cxx

### DIFF
--- a/build/cmake/select_filesystem.cmake
+++ b/build/cmake/select_filesystem.cmake
@@ -49,6 +49,7 @@ elseif(NANA_CMAKE_BOOST_FILESYSTEM_FORCE)
     set(Boost_USE_STATIC_RUNTIME ON)
 
 else()
+    include (CheckIncludeFileCXX)
 
     if(NANA_CMAKE_STD_FILESYSTEM_FORCE)
         target_compile_definitions(nana PUBLIC STD_FILESYSTEM_FORCE)
@@ -87,7 +88,6 @@ else()
 
     if (TEST_FS_LIB)
         include (FindPackageMessage)
-        include (CheckIncludeFileCXX)
         include (CheckCXXSourceCompiles)
         # CMAKE_REQUIRED_FLAGS = string of compile command line flags
         # CMAKE_REQUIRED_DEFINITIONS = list of macros to define (-DFOO=bar)


### PR DESCRIPTION
Fixes CMake error:

```
CMake Error at build/cmake/select_filesystem.cmake:57 (check_include_file_cxx):
  Unknown CMake command "check_include_file_cxx".
```

Platform: Windows 10 / VS 2019
CMake: 3.16.4