### PR TITLE
Replace some naked pointers with unique_ptr.

### DIFF
--- a/include/nana/gui/animation.hpp
+++ b/include/nana/gui/animation.hpp
@@ -38,7 +38,7 @@ namespace nana
 	private:
 		std::shared_ptr<impl> impl_;
 	};
-            /// Easy way to display an animation or create an animated GUI 
+            /// Easy way to display an animation or create an animated GUI
 	class animation
 	{
 		struct branch_t
@@ -46,7 +46,7 @@ namespace nana
 			frameset frames;
 			std::function<std::size_t(const std::string&, std::size_t, std::size_t&)> condition;
 		};
-		
+
 		struct impl;
 		class performance_manager;
 
@@ -73,7 +73,7 @@ namespace nana
 		void fps(std::size_t n);
 		std::size_t fps() const;
 	private:
-		impl * impl_;
+		std::unique_ptr<impl> impl_;
 	};
 }	//end namespace nana
 #include <nana/pop_ignore_diagnostic>

--- a/source/gui/animation.cpp
+++ b/source/gui/animation.cpp
@@ -302,7 +302,7 @@ namespace nana
 		};//end struct frameset::impl
 	//public:
 		frameset::frameset()
-			: impl_(new impl)
+			: impl_(std::make_unique<impl>())
 		{}
 
 		void frameset::push_back(paint::image img)
@@ -449,12 +449,12 @@ namespace nana
 					}
 				}
 
-				auto thr = new thread_variable;
+				auto thr = std::make_unique<thread_variable>();
 				thr->animations.push_back(p);
 				thr->performance_parameter = 0.0;
 				thr->fps = p->fps;
 				thr->interval = 1000.0 / double(p->fps);
-				thr->thread = std::make_shared<std::thread>([thr]()
+				thr->thread = std::make_shared<std::thread>([thr=thr.get()]()
 				{
 					nana::system::timepiece tmpiece;
 					while (true)
@@ -500,8 +500,8 @@ namespace nana
 					}
 				});
 
-				threads_.push_back(thr);
-				p->thr_variable = thr;
+				threads_.push_back(thr.release());
+				p->thr_variable = threads_.back();
 			}
 
 			void animation::performance_manager::set_fps(impl* p, std::size_t new_fps)
@@ -562,30 +562,23 @@ namespace nana
 		//end class animation::performance_manager
 
 		animation::animation(std::size_t fps)
-			: impl_(new impl(fps))
+			: impl_(std::make_unique<impl>(fps))
 		{
 		}
 
-		animation::~animation()
-		{
-			delete impl_;
-		}
+		animation::~animation() = default;
 
 		animation::animation(animation&& rhs)
-			: impl_(rhs.impl_)
+			: impl_(std::move(rhs.impl_))
 		{
-			rhs.impl_ = new impl(23);
+			rhs.impl_ = std::make_unique<impl>(23);
 		}
 
 		animation& animation::operator=(animation&& rhs)
 		{
 			if (this != &rhs)
 			{
-				auto imp = new impl{ 23 };
-
-				delete impl_;
-				impl_ = rhs.impl_;
-				rhs.impl_ = imp;
+				std::swap(rhs.impl_, this->impl_);
 			}
 			return *this;
 		}
@@ -667,7 +660,7 @@ namespace nana
 			if (n == impl_->fps)
 				return;
 
-			impl::perf_manager->set_fps(impl_, n);
+			impl::perf_manager->set_fps(impl_.get(), n);
 		}
 
 		std::size_t animation::fps() const


### PR DESCRIPTION
I noticed some old code still using explicit new/delete. They were trivial to replace with unique_ptr so I went ahead and did it. I think this code is more robust in the presence of exceptions.

I think in operator= swapping is good enough, can't think of any advantage offered by using a new temporary object instead.