### PR TITLE
Initialise everything to make sure accel_key is constexpr.

### DIFF
--- a/include/nana/gui/basis.hpp
+++ b/include/nana/gui/basis.hpp
@@ -33,7 +33,7 @@ namespace nana
 
 	struct accel_key
 	{
-		char key;
+		char key{ '\0' };
 		bool case_sensitive{ false };
 		bool alt{ false };
 		bool ctrl{ false };


### PR DESCRIPTION
Need to initialise everything to make sure classes are usable in a constexpr context.
This is useful for my helper `make_accel_key()` function which I will share shortly.