### PR TITLE
Allow invoking a menu action by index.

### DIFF
--- a/include/nana/gui/widgets/menu.hpp
+++ b/include/nana/gui/widgets/menu.hpp
@@ -171,6 +171,7 @@ namespace nana
 		std::size_t size() const;					///< Return the number of items.
 		int send_shortkey(wchar_t key);
 		void pick();
+		int invoke(std::size_t pos);				//< Send click event to the given entry.
 
 		menu& max_pixels(unsigned);				    ///< Sets the max width in pixels of the item.
 		unsigned max_pixels() const;

--- a/source/gui/widgets/menu.cpp
+++ b/source/gui/widgets/menu.cpp
@@ -1342,6 +1342,28 @@ namespace nana
 				impl_->window_ptr->pick();
 		}
 
+		int menu::invoke (std::size_t pos)
+		{
+			const auto& item_ptr = impl_->mbuilder.data().items[pos];
+			if (!item_ptr->flags.splitter)
+			{
+				if (item_ptr->linked.menu_ptr)
+				{
+					return 2;
+				}
+				else if (item_ptr->flags.enabled)
+				{
+					if (item_ptr->event_handler)
+					{
+						item_proxy ip{ pos, this };
+						item_ptr->event_handler.operator()(ip);
+					}
+					return 1;
+				}
+			}
+			return 0;
+		}
+
 		menu& menu::max_pixels(unsigned px)
 		{
 			impl_->mbuilder.data().max_pixels = (px > 100 ? px : 100);


### PR DESCRIPTION
@cnjinhao I think I need your input on this. Following the hint I was given on issue #525 I tried to add shortcuts to my menu but that created lots of code duplication. For example:

```cpp
my_menubar.at(0).append("E&xit", [](nana::menu::item_proxy&){nana::API::exit();});
my_form.keyboard_accelerator(accel, [](){nana::API::exit();});
```

Since the functor signature is different it's quite hard to re-use the same functor. So now if I want to show an "Are you sure?" dialog I have to remember to do it in two places and create clutter. I'm sure we agree on the problem here.

My idea then was to be able to do this:

```cpp
template <typename F>
void append_to_menu (nana::form& owner, nana::menu& menu, const std::string& text, const F& func, nana::accel_key accel) {
    menu.append(text, func);
    owner.keyboard_accelerator(accel, [&menu,idx=menu.size()-1](){menu.invoke(idx);});
}
```

but I obviously need to be able to trigger the menu entry functor from outside. My code above works form my simple case (with the changes from this PR) but I'm not too sure about my `invoke()` implementation. For example I'm not sure it will work for submenus. What are your thoughts? Was there such a feature already? If not, how can I improve my PR?