### PR TITLE
modified toolbar disabled icons drawing

### DIFF
--- a/include/nana/paint/graphics.hpp
+++ b/include/nana/paint/graphics.hpp
@@ -167,7 +167,7 @@ namespace nana
 			void paste(native_window_type dst, int dx, int dy, unsigned width, unsigned height, int sx, int sy) const;
 			void paste(drawable_type dst, int x, int y) const;
 			void paste(const ::nana::rectangle& r_src, graphics& dst, int x, int y) const;
-			void rgb_to_wb();   ///< Transform a color graphics into black&white.
+			void rgb_to_wb(bool skip_transparent_pixels = false);   ///< Transform a color graphics into black&white.
 
 			void stretch(const ::nana::rectangle& src_r, graphics& dst, const ::nana::rectangle& r) const;
 			void stretch(graphics& dst, const ::nana::rectangle&) const;

--- a/source/gui/widgets/toolbar.cpp
+++ b/source/gui/widgets/toolbar.cpp
@@ -196,10 +196,10 @@ namespace nana
 						{
 							nana::paint::graphics gh(imgsize);
 							gh.bitblt(::nana::rectangle{ imgsize }, graph, pos);
-							gh.rgb_to_wb();
+							gh.rgb_to_wb(true);
 							gh.paste(graph, pos.x, pos.y);
 						}
-						else if (state == state_t::normal)
+						else if(state == state_t::normal)
 						{
 							graph.blend(nana::rectangle(pos, imgsize), ::nana::color(0xc0, 0xdd, 0xfc).blend(bgcolor, 0.5), 0.25);
 						}

--- a/source/paint/graphics.cpp
+++ b/source/paint/graphics.cpp
@@ -841,7 +841,7 @@ namespace paint
 			}
 		}
 
-		void graphics::rgb_to_wb()
+		void graphics::rgb_to_wb(bool skip_transparent_pixels)
 		{
 			if(impl_->handle)
 			{
@@ -871,25 +871,39 @@ namespace paint
 					const auto end = pixels + length_align4;
 					for(; pixels < end; pixels += 4)
 					{
-						unsigned char gray = static_cast<unsigned char>(table_red[pixels[0].element.red] + table_green[pixels[0].element.green] + table_blue[pixels[0].element.blue] + 0.5f);
-						pixels[0].value = gray << 16 | gray << 8| gray;
+						unsigned char gray;
 
-						gray = static_cast<unsigned char>(table_red[pixels[1].element.red] + table_green[pixels[1].element.green] + table_blue[pixels[1].element.blue] + 0.5f);
-						pixels[1].value = gray << 16 | gray << 8 | gray;
-
-						gray = static_cast<unsigned char>(table_red[pixels[2].element.red] + table_green[pixels[2].element.green] + table_blue[pixels[2].element.blue] + 0.5f);
-						pixels[2].value = gray << 16 | gray << 8 | gray;
-
-						gray = static_cast<unsigned char>(table_red[pixels[3].element.red] + table_green[pixels[3].element.green] + table_blue[pixels[3].element.blue] + 0.5f);
-						pixels[3].value = gray << 16 | gray << 8 | gray;
+						if(!skip_transparent_pixels || (skip_transparent_pixels && pixels[0].element.alpha_channel))
+						{
+							gray = static_cast<unsigned char>(table_red[pixels[0].element.red] + table_green[pixels[0].element.green] + table_blue[pixels[0].element.blue] + 0.5f);
+							pixels[0].value = gray << 16 | gray << 8 | gray;
+						}
+						if(!skip_transparent_pixels || (skip_transparent_pixels && pixels[1].element.alpha_channel))
+						{
+							gray = static_cast<unsigned char>(table_red[pixels[1].element.red] + table_green[pixels[1].element.green] + table_blue[pixels[1].element.blue] + 0.5f);
+							pixels[1].value = gray << 16 | gray << 8 | gray;
+						}
+						if(!skip_transparent_pixels || (skip_transparent_pixels && pixels[2].element.alpha_channel))
+						{
+							gray = static_cast<unsigned char>(table_red[pixels[2].element.red] + table_green[pixels[2].element.green] + table_blue[pixels[2].element.blue] + 0.5f);
+							pixels[2].value = gray << 16 | gray << 8 | gray;
+						}
+						if(!skip_transparent_pixels || (skip_transparent_pixels && pixels[3].element.alpha_channel))
+						{
+							gray = static_cast<unsigned char>(table_red[pixels[3].element.red] + table_green[pixels[3].element.green] + table_blue[pixels[3].element.blue] + 0.5f);
+							pixels[3].value = gray << 16 | gray << 8 | gray;
+						}
 					}
 
 					for(int i = 0; i < rest; ++i)
 					{
-						unsigned char gray = static_cast<unsigned char>(table_red[pixels[i].element.red] + table_green[pixels[i].element.green] + table_blue[pixels[i].element.blue] + 0.5f);
-						pixels[i].element.red = gray;
-						pixels[i].element.green = gray;
-						pixels[i].element.blue = gray;
+						if(!skip_transparent_pixels || (skip_transparent_pixels && pixels[1].element.alpha_channel))
+						{
+							unsigned char gray = static_cast<unsigned char>(table_red[pixels[i].element.red] + table_green[pixels[i].element.green] + table_blue[pixels[i].element.blue] + 0.5f);
+							pixels[i].element.red = gray;
+							pixels[i].element.green = gray;
+							pixels[i].element.blue = gray;
+						}
 					}
 
 					pixels += rest;


### PR DESCRIPTION
Ciao,

I modified the way toolbar draw the icons of disabled items.
What I didn't like was the gray square around the disabled icons even if the icons had transparent pixels.
Basically I modified the graphics::rgb_to_wb function adding a flag to skip the transparent pixels of the icons.
Here the result:
![toolbar](https://user-images.githubusercontent.com/16460595/82463930-bd152f00-9abd-11ea-96ec-514871d013b2.png)

For sure there are better way to implement this behavior... I chose the easier without digging to deep into graphic/image code.
