### PR TITLE
Hotfix 1.7.4 new toolbar interface

### DIFF
--- a/include/nana/gui/widgets/float_listbox.hpp
+++ b/include/nana/gui/widgets/float_listbox.hpp
@@ -54,7 +54,8 @@ namespace nana
 
 				virtual ~item_renderer() = default;
 				virtual void image(bool enabled, unsigned pixels) = 0;
-				virtual void render(widget_reference, graph_reference, const nana::rectangle&, const item_interface*, state_t) = 0;
+				virtual void background(widget_reference, graph_reference) = 0;
+				virtual void item(widget_reference, graph_reference, const nana::rectangle&, const item_interface*, state_t) = 0;
 				virtual unsigned item_pixels(graph_reference) const = 0;
 			};
 
@@ -102,6 +103,7 @@ namespace nana
 		void move_items(bool upwards, bool circle);
 		void renderer(item_renderer*);
 		std::size_t index() const;
+		void deselect_on_mouse_leave(bool);
 	};
 }
 #include <nana/pop_ignore_diagnostic>

--- a/include/nana/gui/widgets/toolbar.hpp
+++ b/include/nana/gui/widgets/toolbar.hpp
@@ -33,64 +33,77 @@ namespace nana
 	{
 		namespace toolbar
 		{
+#if 1 //deprecated
 			enum class tool_type
 			{
 				button,
 				toggle
 			};
+#endif
+			enum class tools
+			{
+				separator,
+				button,
+				toggle,
+				dropdown
+			};
+
+			struct toolbar_item;
+			class item_container;
+			class item_proxy;
+
+			/// A callback functor type.
+			typedef std::function<void(item_proxy&)> event_fn_t;
 
 		    class item_proxy
 		    {
 			public:
-				item_proxy(::nana::toolbar*, std::size_t pos);
+				item_proxy() = default;
+				item_proxy(toolbar_item* item, item_container* cont, nana::toolbar* tb);
+#if 1 //deprecated
+				item_proxy& tooltype(tool_type type); ///< Deprecated. Use type instead.
+				bool istoggle() const; ///< Deprecated. Use type instead.
+#endif
+				bool empty() const;  ///< Returns the item_proxy state.
 
-				bool enable() const;
-				item_proxy& enable(bool enable_state);
+				bool enable() const; ///< Gets the tool enable state.
+				item_proxy& enable(bool enable_state); ///< Sets the tool enable state.
 
-				item_proxy& tooltype(tool_type type); ///< Sets the tool style.
+				tools type() const; ///< Gets the tool type.
+				item_proxy& type(tools type); ///< Sets the tool type.
+				
+				item_proxy& textout(bool show); ///< Show/Hide the text inside the tool.
 
-				bool istoggle() const; ///< Returns true if the tool style is toggle.
+				item_proxy& answerer(const event_fn_t& handler);  ///< Sets answerer of the tool.
+
+				// tools::toggle
 				bool toggle() const; ///< Gets the tool toggle state (only if tool style is toggle).
 				item_proxy& toggle(bool toggle_state); ///< Sets the tool toggle state (only if tool style is toggle).
 				std::string toggle_group() const;	///< Returns the toggle group associated with the tool (only if tool style is toggle).
-				item_proxy& toggle_group(const ::std::string& group);	///< Adds the tool to a toggle group (only if tool style is toggle).
+				item_proxy& toggle_group(const std::string& group);	///< Adds the tool to a toggle group (only if tool style is toggle).
 
-				item_proxy& textout(bool show); ///< Show/Hide the text inside the button
+				// tools::dropdown
+				item_proxy& dropdown_append(const std::string& text, const nana::paint::image& img, const event_fn_t& handler = {});   ///< Adds an item to the dropdown menu.
+				item_proxy& dropdown_append(const std::string& text, const event_fn_t& handler = {});   ///< Adds an item to the dropdown menu.
+
+				bool dropdown_enable(std::size_t index) const; ///< Gets the dropdown menu item enable state.
+				item_proxy& dropdown_enable(std::size_t index, bool enable_state); ///< Sets the dropdown menu item enable state.
+
+				item_proxy& dropdown_answerer(std::size_t index, const event_fn_t& handler);  ///< Sets answerer of the dropdown menu item.
 
 			private:
-				nana::toolbar* const tb_;
-				std::size_t const pos_;
+				toolbar_item* item_{ nullptr };
+				item_container* cont_{ nullptr };
+				nana::toolbar* const tb_{ nullptr };
 		    };
-
-			struct item_type
-			{
-				std::string text;
-				nana::paint::image image;
-				unsigned	pixels{ 0 };
-				unsigned	position{ 0 }; // last item position.
-				nana::size	textsize;
-				bool		enable{ true };
-
-				tool_type	type{ tool_type::button };
-				bool		toggle{ false };
-				std::string group;
-
-				bool		textout{ false };
-
-				item_type(const std::string& text, const nana::paint::image& img, tool_type type)
-					:text(text), image(img), type(type)
-				{}
-			};
 
 			struct toolbar_events
 				: public general_events
 			{
-				basic_event<arg_toolbar> selected;	///< A mouse click on a control button.
-				basic_event<arg_toolbar> enter;		///< The mouse enters a control button.
-				basic_event<arg_toolbar> leave;		///< The mouse leaves a control button.
+				basic_event<arg_toolbar> selected;	///< A mouse click on a tool.
+				basic_event<arg_toolbar> enter;		///< The mouse enters a tool.
+				basic_event<arg_toolbar> leave;		///< The mouse leaves a tool.
 			};
-
-			class item_container;
 
 			class drawer
 				: public drawer_trigger
@@ -115,7 +128,7 @@ namespace nana
 				void mouse_up(graph_reference, const arg_mouse&)	override;
 			private:
 				size_type _m_which(point, bool want_if_disabled) const;
-				void _m_calc_pixels(item_type*, bool force);
+				void _m_calc_pixels(toolbar_item*, bool force);
 			private:
 				::nana::toolbar*	widget_;
 				drawer_impl_type*	impl_;
@@ -129,35 +142,57 @@ namespace nana
 		: public widget_object<category::widget_tag, drawerbase::toolbar::drawer, drawerbase::toolbar::toolbar_events>
 	{
 	public:
-		using size_type = std::size_t;      ///< A type to count the number of elements.
+		///< A type to count the number of elements.
+		using size_type = std::size_t;
+
+#if 1 //deprecated
 		using tool_type = drawerbase::toolbar::tool_type;
+#endif
+		/// Iterator to access item
+		using item_proxy = drawerbase::toolbar::item_proxy;
+
+		/// Toolbar tools type enum
+		using tools = drawerbase::toolbar::tools;
+
+		/// A callback functor type. Prototype: `void(item_proxy&)`
+		using event_fn_t = drawerbase::toolbar::event_fn_t;
+
 
 		toolbar() = default;
 		toolbar(window, bool visible, bool detached=false);
 		toolbar(window, const rectangle& = rectangle(), bool visible = true, bool detached = false);
 
-		void separate();                      ///< Adds a separator.
-		drawerbase::toolbar::item_proxy append(const ::std::string& text, const nana::paint::image& img);   ///< Adds a control button.
-		drawerbase::toolbar::item_proxy append(const ::std::string& text);   ///< Adds a control button.
-		void clear();   ///< Removes all control buttons and separators.
+#if 1 //deprecated
+		void separate(); ///< Deprecated. Use append_separator() instead.
+		item_proxy append(const ::std::string& text, const nana::paint::image& img);   ///< Deprecated. Use append(tool, text, img, fn) instead.
+		item_proxy append(const ::std::string& text);   ///< Deprecated. Use append(tool, text, fn) instead.
+#endif
+
+		item_proxy append(tools t, const std::string& text, const nana::paint::image& img, const event_fn_t& handler = {});   ///< Adds a tool.
+		item_proxy append(tools t, const std::string& text, const event_fn_t& handler = {});   ///< Adds a tool.
+		void append_separator();	///< Adds a separator.
+
+		size_type count() const noexcept; ///< Returns tools and separators count.
+		item_proxy at(size_type pos);	///< Returns tool at specified position.
+
+		void clear();   ///< Removes all tools and separators.
 		
-		bool enable(size_type index) const;
-		void enable(size_type index, bool enable_state);
+		bool enable(size_type index) const; ///< Gets the tool enable state.
+		void enable(size_type index, bool enable_state); ///< Sets the tool enable state.
 
-		void tooltype(size_type index, tool_type type); ///< Sets the tool style.
+#if 1 //deprecated
+		void tooltype(size_type index, tool_type type); ///< Deprecated. Use at[index].type instead.
+		bool istoggle(size_type index) const;  ///< Deprecated. Use at[index].type instead.
+		bool toggle(size_type index) const;  ///< Deprecated. Use at[index].toggle instead.
+		void toggle(size_type index, bool toggle_state);  ///< Deprecated. Use at[index].toggle instead.
+		std::string toggle_group(size_type index) const;  ///< Deprecated. Use at[index].toggle_group instead.
+		void toggle_group(size_type index, const ::std::string& group);  ///< Deprecated. Use at[index].toggle_group instead.
+		void textout(size_type index, bool show);  ///< Deprecated. Use at[index].textout instead.
+		void scale(unsigned s);  ///< Deprecated. Use tools_height instead.
+#endif
 
-		bool istoggle(size_type index) const; ///< Returns true if the tool style is toggle.
-		bool toggle(size_type index) const; ///< Gets the tool toggle state (only if tool style is toggle).
-		void toggle(size_type index, bool toggle_state); ///< Sets the tool toggle state (only if tool style is toggle).
-		std::string toggle_group(size_type index) const;	///< Returns the toggle group associated with the tool (only if tool style is toggle).
-		void toggle_group(size_type index, const ::std::string& group);	///< Adds the tool to a toggle group (only if tool style is toggle).
-
-		void textout(size_type index, bool show); ///< Show/Hide the text inside the button
-
-		void scale(unsigned s);   ///< Sets the scale of control button.
-
-		/// Enable to place buttons at right part. After calling it, every new button is right aligned.
-		void go_right();
+		void tools_height(unsigned h);   ///< Sets the height of tools.
+		void go_right(); ///< Enable to place tools at right part. After calling it, every new tool is right aligned.
 
 		bool detached() { return detached_; };
 

--- a/include/nana/paint/graphics.hpp
+++ b/include/nana/paint/graphics.hpp
@@ -167,7 +167,7 @@ namespace nana
 			void paste(native_window_type dst, int dx, int dy, unsigned width, unsigned height, int sx, int sy) const;
 			void paste(drawable_type dst, int x, int y) const;
 			void paste(const ::nana::rectangle& r_src, graphics& dst, int x, int y) const;
-			void rgb_to_wb();   ///< Transform a color graphics into black&white.
+			void rgb_to_wb(bool skip_transparent_pixels = false);   ///< Transform a color graphics into black&white.
 
 			void stretch(const ::nana::rectangle& src_r, graphics& dst, const ::nana::rectangle& r) const;
 			void stretch(graphics& dst, const ::nana::rectangle&) const;

--- a/source/gui/widgets/float_listbox.cpp
+++ b/source/gui/widgets/float_listbox.cpp
@@ -33,7 +33,13 @@ namespace nana
 					image_pixels_ = px;
 				}
 
-				void render(widget_reference, graph_reference graph, const nana::rectangle& r, const item_interface* item, state_t state)
+				void background(widget_reference, graph_reference graph)
+				{
+					graph.rectangle(false, colors::black);
+					graph.rectangle(nana::rectangle(graph.size()).pare_off(1), false, colors::white);
+				}
+
+				void item(widget_reference, graph_reference graph, const nana::rectangle& r, const item_interface* item, state_t state)
 				{
 					if (state == StateHighlighted)
 					{
@@ -298,7 +304,17 @@ namespace nana
 							return true;
 						}
 					}
+					else if(deselect_on_mouse_leave_ && npos != state_.index)
+					{
+						state_.index = npos;
+						return true;
+					}
 					return false;
+				}
+
+				void deselect_on_mouse_leave(bool value)
+				{
+					deselect_on_mouse_leave_ = value;
 				}
 
 				void draw()
@@ -322,7 +338,7 @@ namespace nana
 							{
 								auto state = (i != state_.index ? item_renderer::StateNone : item_renderer::StateHighlighted);
 
-								state_.renderer->render(*widget_, *graph_, item_r, module_->items[i].get(), state);
+								state_.renderer->item(*widget_, *graph_, item_r, module_->items[i].get(), state);
 								item_r.y += item_pixels;
 							}
 						}	
@@ -332,8 +348,7 @@ namespace nana
 						graph_->string({ 4, 4 }, L"Empty Listbox, No Module!", static_cast<color_rgb>(0x808080));
 
 					//Draw border
-					graph_->rectangle(false, colors::black);
-					graph_->rectangle(nana::rectangle(graph_->size()).pare_off(1), false, colors::white);
+					state_.renderer->background(*widget_, *graph_);
 				}
 			private:
 				bool _m_image_enabled() const
@@ -386,6 +401,10 @@ namespace nana
 				unsigned image_pixels_{16};		//Define the width pixels of the image area
 
 				bool ignore_first_mouseup_{true};
+
+				bool deselect_on_mouse_leave_{ false }; //false: is the behaviour of the combox
+													   //true: is the behaviour of the menu
+
 				struct state_type
 				{
 					std::size_t offset_y{0};
@@ -510,6 +529,11 @@ namespace nana
 		std::size_t float_listbox::index() const
 		{
 			return get_drawer_trigger().get_drawer_impl().index();
+		}
+
+		void float_listbox::deselect_on_mouse_leave(bool value)
+		{
+			get_drawer_trigger().get_drawer_impl().deselect_on_mouse_leave(value);
 		}
 	//end class float_listbox
 }

--- a/source/gui/widgets/toolbar.cpp
+++ b/source/gui/widgets/toolbar.cpp
@@ -196,10 +196,10 @@ namespace nana
 						{
 							nana::paint::graphics gh(imgsize);
 							gh.bitblt(::nana::rectangle{ imgsize }, graph, pos);
-							gh.rgb_to_wb();
+							gh.rgb_to_wb(true);
 							gh.paste(graph, pos.x, pos.y);
 						}
-						else if (state == state_t::normal)
+						else if(state == state_t::normal)
 						{
 							graph.blend(nana::rectangle(pos, imgsize), ::nana::color(0xc0, 0xdd, 0xfc).blend(bgcolor, 0.5), 0.25);
 						}

--- a/source/paint/graphics.cpp
+++ b/source/paint/graphics.cpp
@@ -841,7 +841,7 @@ namespace paint
 			}
 		}
 
-		void graphics::rgb_to_wb()
+		void graphics::rgb_to_wb(bool skip_transparent_pixels)
 		{
 			if(impl_->handle)
 			{
@@ -871,25 +871,39 @@ namespace paint
 					const auto end = pixels + length_align4;
 					for(; pixels < end; pixels += 4)
 					{
-						unsigned char gray = static_cast<unsigned char>(table_red[pixels[0].element.red] + table_green[pixels[0].element.green] + table_blue[pixels[0].element.blue] + 0.5f);
-						pixels[0].value = gray << 16 | gray << 8| gray;
+						unsigned char gray;
 
-						gray = static_cast<unsigned char>(table_red[pixels[1].element.red] + table_green[pixels[1].element.green] + table_blue[pixels[1].element.blue] + 0.5f);
-						pixels[1].value = gray << 16 | gray << 8 | gray;
-
-						gray = static_cast<unsigned char>(table_red[pixels[2].element.red] + table_green[pixels[2].element.green] + table_blue[pixels[2].element.blue] + 0.5f);
-						pixels[2].value = gray << 16 | gray << 8 | gray;
-
-						gray = static_cast<unsigned char>(table_red[pixels[3].element.red] + table_green[pixels[3].element.green] + table_blue[pixels[3].element.blue] + 0.5f);
-						pixels[3].value = gray << 16 | gray << 8 | gray;
+						if(!skip_transparent_pixels || (skip_transparent_pixels && pixels[0].element.alpha_channel))
+						{
+							gray = static_cast<unsigned char>(table_red[pixels[0].element.red] + table_green[pixels[0].element.green] + table_blue[pixels[0].element.blue] + 0.5f);
+							pixels[0].value = gray << 16 | gray << 8 | gray;
+						}
+						if(!skip_transparent_pixels || (skip_transparent_pixels && pixels[1].element.alpha_channel))
+						{
+							gray = static_cast<unsigned char>(table_red[pixels[1].element.red] + table_green[pixels[1].element.green] + table_blue[pixels[1].element.blue] + 0.5f);
+							pixels[1].value = gray << 16 | gray << 8 | gray;
+						}
+						if(!skip_transparent_pixels || (skip_transparent_pixels && pixels[2].element.alpha_channel))
+						{
+							gray = static_cast<unsigned char>(table_red[pixels[2].element.red] + table_green[pixels[2].element.green] + table_blue[pixels[2].element.blue] + 0.5f);
+							pixels[2].value = gray << 16 | gray << 8 | gray;
+						}
+						if(!skip_transparent_pixels || (skip_transparent_pixels && pixels[3].element.alpha_channel))
+						{
+							gray = static_cast<unsigned char>(table_red[pixels[3].element.red] + table_green[pixels[3].element.green] + table_blue[pixels[3].element.blue] + 0.5f);
+							pixels[3].value = gray << 16 | gray << 8 | gray;
+						}
 					}
 
 					for(int i = 0; i < rest; ++i)
 					{
-						unsigned char gray = static_cast<unsigned char>(table_red[pixels[i].element.red] + table_green[pixels[i].element.green] + table_blue[pixels[i].element.blue] + 0.5f);
-						pixels[i].element.red = gray;
-						pixels[i].element.green = gray;
-						pixels[i].element.blue = gray;
+						if(!skip_transparent_pixels || (skip_transparent_pixels && pixels[1].element.alpha_channel))
+						{
+							unsigned char gray = static_cast<unsigned char>(table_red[pixels[i].element.red] + table_green[pixels[i].element.green] + table_blue[pixels[i].element.blue] + 0.5f);
+							pixels[i].element.red = gray;
+							pixels[i].element.green = gray;
+							pixels[i].element.blue = gray;
+						}
 					}
 
 					pixels += rest;


### PR DESCRIPTION
Hi,
I worked a little on the toolbar here a brief list of changes:
- redesigned toolbar interface
- added dropdown tool
![dd](https://user-images.githubusercontent.com/16460595/83270263-811e5000-a1c8-11ea-9bae-89148a7b5754.png)

More in detail:
1) added a new version of the append member functions where the first parameter is the tool-type and the last (optional) the event handler. The event is raised when the tool is clicked. The old append member functions are marked as deprecated.

2) added tools_height. This is a replacement for the scale function marked as deprecated. The new name seems "more clear" to me.

3) added append_separator. This is a replacement for the separate function marked as deprecated. Same as before.

4) added count to gets the number of tools and separators.

5) added at(index) to access the tool at specified position.

6) marked as deprecated some of the member functions I previously added. Now should be accessed only from the tool item_proxy. No reason to have these function directly on the toolbar interface.

7) added dropdown tool (see image above). Added the following item_proxy functions:
   - dropdown_append: adds item to the dropdown menu
   - dropdown_answerer: sets the event handler for the dropmenu item

For sure I'm forgetting some change I made...
... anyway let me know what you think.

Ciao
