### PR TITLE
fix linking error while building shared lib under linux

### DIFF
--- a/build/cmake/shared_libs.cmake
+++ b/build/cmake/shared_libs.cmake
@@ -39,8 +39,11 @@ endif()
 if(NANA_STATIC_STDLIB)
     target_link_libraries(nana
         PUBLIC
-            $<$<CXX_COMPILER_ID:GNU>:-static-libgcc -static-libstdc++>
-            $<$<CXX_COMPILER_ID:Clang>:-static-libgcc -static-libstdc++>
+            $<$<CXX_COMPILER_ID:GNU>:-static-libgcc>
+            $<$<CXX_COMPILER_ID:GNU>:-static-libstdc++>
+            
+            $<$<CXX_COMPILER_ID:Clang>:-static-libgcc>
+            $<$<CXX_COMPILER_ID:Clang>:-static-libstdc++>
             )
 endif()
 


### PR DESCRIPTION
fix linking error while building shared lib under linux (expansion error of CMake generator expressions)