### PR TITLE
Fix : Cmake build error on macOS

### DIFF
--- a/source/system/platform.cpp
+++ b/source/system/platform.cpp
@@ -25,6 +25,7 @@
 	#include <pthread.h>
 	#include <sys/stat.h>
 	#include <spawn.h>
+	#include <errno.h>
 	#include <cstring>
 	#include <memory>
 


### PR DESCRIPTION
I tried building nana library on my mac using cmake.
While I was working on it, the output said some necessary header was not included.
So I included the header file and now I can get libnana.a
