### PR TITLE
added a feature : registering multiple tray icon animations

### DIFF
--- a/include/nana/gui/notifier.hpp
+++ b/include/nana/gui/notifier.hpp
@@ -59,7 +59,11 @@ namespace nana
 		void text(const ::std::string&);
 		void icon(const ::std::string& icon_file);
 		void insert_icon(const ::std::string& icon_file);
-		void period(std::chrono::milliseconds time);
+		void insert_icon(const ::std::string& animation_tag, const ::std::string& icon_file);
+		void period(const std::chrono::milliseconds time);
+		void period(const ::std::string& animation_tag, const std::chrono::milliseconds time);
+		void resume_animation();
+		void stop_animation(const bool complete_stop);
 		detail::notifier_events& events();
 		window handle() const;
 	private:

--- a/source/gui/notifier.cpp
+++ b/source/gui/notifier.cpp
@@ -37,6 +37,7 @@ namespace nana
 
 	struct notifier::implement
 	{
+		using animation_map = ::std::unordered_map<::std::string, ::std::vector<paint::image>>;
 		nana::timer	ani_timer;
 		native_window_type	native_handle;
 		window				handle;
@@ -47,7 +48,8 @@ namespace nana
 		std::size_t	play_index;
 
 		paint::image icon;
-		::std::vector<paint::image> icons;
+		animation_map animations;
+		::std::vector<paint::image>* current_animation{ nullptr };
 
 		void set_icon(const paint::image& ico)
 		{
@@ -256,10 +258,13 @@ namespace nana
 		impl_->ani_timer.elapse([this]
 		{
 #if defined(NANA_WINDOWS)
-			if (impl_->play_index >= impl_->icons.size())
+			if (!impl_->current_animation)
+				return;
+
+			if (impl_->play_index >= impl_->current_animation->size())
 				impl_->play_index = 0;
 
-			auto ico = impl_->icons[impl_->play_index++];
+			auto ico = (*impl_->current_animation)[impl_->play_index++];
 			impl_->set_icon(ico);
 #else
 			//eliminates warnings in clang
@@ -325,8 +330,12 @@ namespace nana
 		auto icon_handle = paint::image_accessor::icon(image_ico);
 		if (icon_handle)
 		{
-			impl_->ani_timer.stop();
-			impl_->play_index = 0;
+			if (impl_->current_animation)
+			{
+				stop_animation(false);
+				impl_->play_index = 0;
+				impl_->current_animation = nullptr;
+			}
 			impl_->set_icon(image_ico);
 			impl_->icon = image_ico;
 		}
@@ -337,30 +346,97 @@ namespace nana
 
 	void notifier::insert_icon(const std::string& icon_file)
 	{
+		insert_icon("notifier_default", icon_file);
+	}
+
+	void notifier::insert_icon(const ::std::string& animation_tag, const ::std::string& icon_file)
+	{
 #if defined(NANA_WINDOWS)
 		paint::image image_ico{ icon_file };
 		auto icon_handle = paint::image_accessor::icon(image_ico);
 		if (icon_handle)
-			impl_->icons.emplace_back(static_cast<paint::image&&>(image_ico));
+		{
+			auto& animation_frames = impl_->animations[animation_tag];
+			animation_frames.emplace_back(std::move(image_ico));
+		}
 #else
+		static_cast<void>(animation_tag);	//eliminate unused parameter warning
 		static_cast<void>(icon_file);	//eliminate unused parameter warning
 #endif
 	}
 
 	void notifier::period(std::chrono::milliseconds ms)
 	{
-#if defined(NANA_WINDOWS)
-		if (ms.count() && impl_->icons.size())
-		{
-			auto frame_ms = (std::max)(ms.count() / static_cast<long long>(impl_->icons.size()), static_cast<long long>(16));
+		period("notifier_default", ms);
+	}
 
-			impl_->ani_timer.interval(std::chrono::milliseconds{frame_ms});
-			impl_->ani_timer.start();
+	void notifier::period(const ::std::string& animation_tag, const std::chrono::milliseconds ms)
+	{
+#if defined(NANA_WINDOWS)
+		if (ms.count() == 0)
+			return;
+
+		const bool animation_not_found = (impl_->animations.find(animation_tag) == impl_->animations.end());
+		if (animation_not_found)
+			return;
+
+		const bool empty_frames = impl_->animations[animation_tag].empty();
+		if (empty_frames)
+			return;
+
+		if (impl_->current_animation)
+		{
+			stop_animation(false);
+			impl_->play_index = 0;
+			impl_->current_animation = nullptr;
 		}
-		else
-			impl_->ani_timer.stop();
+
+		auto& animation_frames = impl_->animations[animation_tag];
+		impl_->current_animation = &animation_frames;
+		const auto frame_ms = (std::max)(ms.count() / static_cast<long long>(animation_frames.size()), static_cast<long long>(16));
+		impl_->ani_timer.interval(std::chrono::milliseconds{ frame_ms });
+		impl_->ani_timer.start();
 #else
+		static_cast<void>(animation_tag);	//to eliminate unused parameter compiler warning.
 		static_cast<void>(ms); //to eliminate unused parameter compiler warning.
+#endif
+	}
+
+	void notifier::resume_animation()
+	{
+#if defined(NANA_WINDOWS)
+		const bool halted_animation_not_found = (impl_->current_animation == nullptr || impl_->ani_timer.started() == true);
+		if (halted_animation_not_found)
+			return;
+
+		impl_->ani_timer.start();
+#endif
+	}
+
+	void notifier::stop_animation(const bool complete_stop)
+	{
+#if defined(NANA_WINDOWS)
+		const bool animation_not_playing = (impl_->current_animation == nullptr || impl_->ani_timer.started() == false);
+		if (animation_not_playing)
+			return;
+
+		impl_->ani_timer.stop();
+		if (complete_stop)
+		{
+			impl_->play_index = 0;
+			if (impl_->icon_added)
+			{
+				impl_->set_icon(impl_->icon);
+			}
+			else
+			{
+				const auto& first_frame = (*impl_->current_animation)[0];
+				impl_->set_icon(first_frame);
+			}
+			impl_->current_animation = nullptr;
+		}
+#else
+		static_cast<void>(complete_stop);	//to eliminate unused parameter compiler warning.
 #endif
 	}
 


### PR DESCRIPTION
I thought it would be nicer if a user can register multiple tray icon animations.
At first, I tried to give `period` function a new name such as `start_animation`.
Then I realized this is a minor version update, which has to ensure the backward compatibility.
So I modified some of the codes and added some new functions in a way that it won't cause a side effect.