### PR TITLE
fix combox rendering issues

### DIFF
--- a/source/gui/widgets/combox.cpp
+++ b/source/gui/widgets/combox.cpp
@@ -201,33 +201,33 @@ namespace nana
 					{
 						editor_->editable(enb, false);
 						editor_->show_caret(enb);
-						if (!enb)
+						editor_->customized_renderers().background = [this, enb](graph_reference graph, const ::nana::rectangle&, const ::nana::color&)
 						{
-							editor_->customized_renderers().background = [this](graph_reference graph, const ::nana::rectangle&, const ::nana::color&)
+							auto clr_from = this->widget_ptr()->bgcolor();
+							auto clr_to = clr_from.blend(colors::white, .1);
+
+							int pare_off_px = 1;
+							if (element_state::pressed == state_.button_state)
 							{
-								auto clr_from = colors::button_face_shadow_start;
-								auto clr_to = colors::button_face_shadow_end;
+								pare_off_px = 2;
+								std::swap(clr_from, clr_to);
+							}
 
-								int pare_off_px = 1;
-								if (element_state::pressed == state_.button_state)
-								{
-									pare_off_px = 2;
-									std::swap(clr_from, clr_to);
-								}
-
+							if(!enb)
 								graph.gradual_rectangle(::nana::rectangle(graph.size()).pare_off(pare_off_px), clr_from, clr_to, true);
-								if (API::is_transparent_background(this->widget_ptr()->handle()))
+							else
+								graph.rectangle(::nana::rectangle(::nana::size{image_pixels_+5, graph.height()}).pare_off(pare_off_px), 
+									true, this->widget_ptr()->bgcolor());
+
+							if (API::is_transparent_background(this->widget_ptr()->handle()))
+							{
+								paint::graphics trns_graph{ graph.size() };
+								if (API::dev::copy_transparent_background(this->widget_ptr()->handle(), trns_graph))
 								{
-									paint::graphics trns_graph{ graph.size() };
-									if (API::dev::copy_transparent_background(this->widget_ptr()->handle(), trns_graph))
-									{
-										graph.blend(rectangle{ trns_graph.size() }, trns_graph, {}, 0.5);
-									}
+									graph.blend(rectangle{ trns_graph.size() }, trns_graph, {}, 0.5);
 								}
-							};
-						}
-						else
-							editor_->customized_renderers().background = nullptr;
+							}
+						};
 
 						editor_->enable_background(enb);
 						editor_->enable_background_counterpart(!enb);
@@ -567,7 +567,7 @@ namespace nana
 						}
 					}
 
-					nana::point pos((image_pixels_ - imgsz.width) / 2 + 2, (vpix - imgsz.height) / 2 + 2);
+					nana::point pos((image_pixels_ - imgsz.width) / 2 + 2, (widget_ptr()->size().height - imgsz.height) / 2);
 					img.stretch(::nana::rectangle{ img.size() }, *graph_, nana::rectangle(pos, imgsz));
 				}
 			private:


### PR DESCRIPTION
This commit solves three combox rendering issues:

1. if one or more list items has an image, and the combox is editable, the background of the image area to the left of the text editor isn't drawn (resulting in a black background area to the left of the text)
2. if one or more list items has an image, the image is not centered vertically when drawn to the left of the text editor
3. if the combox is not editable, the background of text editor area uses predefined constants for the color gradient, ignoring the widget's scheme bgcolor

![combox_bugs](https://user-images.githubusercontent.com/20293505/97712347-b2ab8800-1a94-11eb-970f-86fe4fb3b502.png)
