### PR TITLE
renamed some variables to prevent shadowing warning

### DIFF
--- a/include/nana/gui/place.hpp
+++ b/include/nana/gui/place.hpp
@@ -159,9 +159,9 @@ namespace nana
 		template<typename Panel, typename ...Args>
 		place& dock(const std::string& dockname, const std::string& factory_name, Args&& ... args)
 		{
-			return dock(dockname, factory_name, std::bind([](window parent, Args & ... args)
+			return dock(dockname, factory_name, std::bind([](window parent, Args & ... dock_args)
 			{
-				return std::unique_ptr<widget>(new Panel(parent, std::forward<Args>(args)...));
+				return std::unique_ptr<widget>(new Panel(parent, std::forward<Args>(dock_args)...));
 			}, std::placeholders::_1, args...));
 		}
 

--- a/include/nana/gui/widgets/combox.hpp
+++ b/include/nana/gui/widgets/combox.hpp
@@ -183,9 +183,9 @@ namespace nana
 		item_proxy operator[](const Key& kv)
 		{
 			typedef typename nana::detail::type_escape<Key>::type key_t;
-			std::shared_ptr<nana::detail::key_interface> p(new nana::key<key_t, std::less<key_t> >(kv), [](nana::detail::key_interface*p)
+			std::shared_ptr<nana::detail::key_interface> p(new nana::key<key_t, std::less<key_t> >(kv), [](nana::detail::key_interface*pki)
 			{
-				delete p;
+				delete pki;
 			});
 
 			return _m_at_key(std::move(p));


### PR DESCRIPTION
Hi, 

   I normally compile with g++ using the warning switch -Wshadow=local , which gives me an alert when a variable in a function is shadowing another one such as a parameter of the function itself. By this switch I've noticed that a couple of files in nana have this problem (combox.hpp and place.hpp), so I've changed there the name of the variable.
   
    Recompiled nana and tested : I get no more shadow warnings in my programs and they work fine.
	
	
   Thanks,
   
         Marco