### PR TITLE
Fix syntax error when building with VS 2019

### DIFF
--- a/source/system/split_string.cpp
+++ b/source/system/split_string.cpp
@@ -18,7 +18,7 @@ std::vector<split_string_type> split_string (const split_string_type& text, char
 		sep_pos = text.find(sep, sep_pos);
 		sep_pos = (text.npos == sep_pos ? text.size() : sep_pos);
 		const std::size_t end = sep_pos;
-		while (sep_pos < text.size() and sep == text[sep_pos]) {
+		while (sep_pos < text.size() && sep == text[sep_pos]) {
 			++sep_pos;
 		}
 


### PR DESCRIPTION
Hi,
This is a quick fix for #585. It removes the syntax error, when building using Visual Studio, by replacing `and` keyword with `&&` in one of the conditions.