### PR TITLE
Added ability to call api::enable_double_click

### DIFF
--- a/include/nana/gui/programming_interface.hpp
+++ b/include/nana/gui/programming_interface.hpp
@@ -245,6 +245,8 @@ namespace api
 	native_window_type root(window);
 	window	root(native_window_type);                     ///< Retrieves the native window of a Nana.GUI window.
 
+	void enable_double_click(window, bool);
+
 	void fullscreen(window, bool);
 
 	void close_window(window);


### PR DESCRIPTION
The code to `enable/disable` the double click event for a widget already existed in [source/gui/programming_interface.cpp](https://github.com/cnjinhao/nana/blob/develop-1.8/source/gui/programming_interface.cpp#L609-L614) but it seems that it was missed out in `include/nana/gui/programming_interface.hpp`, so I have added it.

This now allows us to call `api::enable_double_click(window wd, bool dbl);`
Which is useful if you want to be able to rapidly click on a button and have every click emit a click event, rather than every other click.