### PR TITLE
Fixed nana::progress borderless bug. Also implemented a border_color struct in the scheme.

### DIFF
--- a/include/nana/gui/widgets/progress.hpp
+++ b/include/nana/gui/widgets/progress.hpp
@@ -25,6 +25,14 @@ namespace nana
 
 				color_proxy gradient_bgcolor{ colors::button_face_shadow_start };
 				color_proxy gradient_fgcolor{ static_cast<color_rgb>(0x6FFFA8) };
+				
+				struct
+				{
+					color_proxy left { colors::gray };
+                    color_proxy top { colors::gray };
+                    color_proxy right { colors::white };
+                    color_proxy bottom { colors::white };
+				} border_colors;
 			};
 
 			class substance;

--- a/include/nana/gui/widgets/progress.hpp
+++ b/include/nana/gui/widgets/progress.hpp
@@ -23,8 +23,8 @@ namespace nana
 			{
 				scheme();
 
-				color_proxy gradient_bgcolor{ colors::button_face_shadow_start };
-				color_proxy gradient_fgcolor{ static_cast<color_rgb>(0x6FFFA8) };
+				color_proxy lower_background{ colors::button_face_shadow_start };
+				color_proxy lower_foreground{ static_cast<color_rgb>(0x6FFFA8) };
 				
 				struct
 				{

--- a/include/nana/gui/widgets/progress.hpp
+++ b/include/nana/gui/widgets/progress.hpp
@@ -29,9 +29,9 @@ namespace nana
 				struct
 				{
 					color_proxy left { colors::gray };
-                    color_proxy top { colors::gray };
-                    color_proxy right { colors::white };
-                    color_proxy bottom { colors::white };
+					color_proxy top { colors::gray };
+					color_proxy right { colors::white };
+					color_proxy bottom { colors::white };
 				} border_colors;
 			};
 
@@ -53,8 +53,8 @@ namespace nana
 			};
 	}//end namespace drawerbase::progress
 	
-       /// \brief A progressbar widget with two styles: know, and unknown amount value (goal). 
-       /// In unknown style the amount is ignored and the bar is scrolled when value change.
+	   /// \brief A progressbar widget with two styles: know, and unknown amount value (goal). 
+	   /// In unknown style the amount is ignored and the bar is scrolled when value change.
 	class progress
 		: public widget_object<category::widget_tag, drawerbase::progress::trigger, ::nana::general_events, drawerbase::progress::scheme>
 	{

--- a/source/gui/widgets/progress.cpp
+++ b/source/gui/widgets/progress.cpp
@@ -143,7 +143,7 @@ namespace nana
 
 		void trigger::refresh(graph_reference graph)
 		{	
-			const unsigned border_px = substance::border_px;
+			const unsigned border_px = api::widget_borderless(*progress_->widget_ptr()) ? 0 : substance::border_px;
 
 			rectangle rt_val{ graph.size() };
 			auto const width = rt_val.width - border_px * 2;
@@ -206,7 +206,8 @@ namespace nana
 			else
 				graph.gradual_rectangle(rt_val, sch.gradient_fgcolor.get_color(), fgcolor, true);
 
-			graph.frame_rectangle(rectangle{ graph.size() }, colors::gray, colors::gray, colors::white, colors::white);
+			if (!api::widget_borderless(*progress_->widget_ptr()))
+				graph.frame_rectangle(rectangle{ graph.size() }, colors::gray, colors::gray, colors::white, colors::white);
 		}
 	}//end namespace drawerbase::progress
 

--- a/source/gui/widgets/progress.cpp
+++ b/source/gui/widgets/progress.cpp
@@ -190,10 +190,10 @@ namespace nana
 			if (bgcolor.invisible())
 				bgcolor = colors::button_face;
 
-			if (sch.gradient_bgcolor.get_color().invisible())
+			if (sch.lower_background.get_color().invisible())
 				graph.rectangle(rt_bground, true, bgcolor);
 			else
-				graph.gradual_rectangle(rt_bground, bgcolor, sch.gradient_bgcolor.get_color(), true);
+				graph.gradual_rectangle(rt_bground, bgcolor, sch.lower_background.get_color(), true);
 
 			//Draw the gradient fgcolor if gradient_fgcolor is available.
 
@@ -201,10 +201,10 @@ namespace nana
 			if (fgcolor.invisible())
 				fgcolor = static_cast<color_rgb>(0x107515);
 
-			if (sch.gradient_fgcolor.get_color().invisible())
+			if (sch.lower_foreground.get_color().invisible())
 				graph.rectangle(rt_val, true, fgcolor);
 			else
-				graph.gradual_rectangle(rt_val, sch.gradient_fgcolor.get_color(), fgcolor, true);
+				graph.gradual_rectangle(rt_val, sch.lower_foreground.get_color(), fgcolor, true);
 
 			if (!api::widget_borderless(*progress_->widget_ptr()))
 				graph.frame_rectangle(rectangle { graph.size() },

--- a/source/gui/widgets/progress.cpp
+++ b/source/gui/widgets/progress.cpp
@@ -94,7 +94,7 @@ namespace nana
 			{
 				if (widget_)
 				{
-                    unsigned value_px = (widget_->size().width - border_px * 2);
+					unsigned value_px = (widget_->size().width - border_px * 2);
 
 					//avoid overflow
 					if (unknown_ || (value_ < max_))
@@ -210,8 +210,8 @@ namespace nana
 				graph.frame_rectangle(rectangle { graph.size() },
 					sch.border_colors.left.get_color(),
 					sch.border_colors.top.get_color(),
-                    sch.border_colors.right.get_color(),
-                    sch.border_colors.bottom.get_color());
+					sch.border_colors.right.get_color(),
+					sch.border_colors.bottom.get_color());
 		}
 	}//end namespace drawerbase::progress
 

--- a/source/gui/widgets/progress.cpp
+++ b/source/gui/widgets/progress.cpp
@@ -207,7 +207,11 @@ namespace nana
 				graph.gradual_rectangle(rt_val, sch.gradient_fgcolor.get_color(), fgcolor, true);
 
 			if (!api::widget_borderless(*progress_->widget_ptr()))
-				graph.frame_rectangle(rectangle{ graph.size() }, colors::gray, colors::gray, colors::white, colors::white);
+				graph.frame_rectangle(rectangle { graph.size() },
+					sch.border_colors.left.get_color(),
+					sch.border_colors.top.get_color(),
+                    sch.border_colors.right.get_color(),
+                    sch.border_colors.bottom.get_color());
 		}
 	}//end namespace drawerbase::progress
 


### PR DESCRIPTION
Please take a look.
I believe the borderless behavior required a simple fix, so I think it should be ok as-is.
Let me know what you think about the second commit, [d88193a](https://github.com/cnjinhao/nana/commit/d88193a765ba909fdbf6f4388a56fee2f9286f01). It adds a struct containing four sides of the widget to color. Maybe a solution similar to this would be an interesting fit for other widgets as well, but I'd really like to hear what you think about this design first.

My IDE had also screwed the indentation, so I sent a third commit to fix it.

Finally, I also renamed the scheme elements as discussed in the issue.

Fixes #604 