### PR TITLE
fix checkbox square misaligned with text

### DIFF
--- a/source/gui/widgets/checkbox.cpp
+++ b/source/gui/widgets/checkbox.cpp
@@ -83,7 +83,7 @@ namespace nana{ namespace drawerbase
 
 				unsigned txt_px = 0, descent = 0, ileading = 0;
 				graph.text_metrics(txt_px, descent, ileading);
-				txt_px += (descent + 2);
+				txt_px += (descent + ileading);
 
 				auto e_state = API::element_state(*wdg);
 				if(!wdg->enabled())


### PR DESCRIPTION
before:
![cbox_before](https://user-images.githubusercontent.com/20293505/106898627-6dfe4100-66c2-11eb-9f6e-2cef5dad21b0.png)

after: 
![cbox_after](https://user-images.githubusercontent.com/20293505/106898661-7787a900-66c2-11eb-9fdc-79ef7703f0ca.png)
