### PR TITLE
add listbox::items() method to get all items index_pairs

### DIFF
--- a/include/nana/gui/widgets/listbox.hpp
+++ b/include/nana/gui/widgets/listbox.hpp
@@ -1590,6 +1590,7 @@ the nana::detail::basic_window member pointer scheme
 		///< Prevent sorting until `freeze` is set to false.
 		bool freeze_sort(bool freeze);
 
+		index_pairs items() const;		    ///<Get the absolute indexes of all items
 		index_pairs selected() const;		///<Get the absolute indexes of all the selected items
 
 		void show_header(bool);

--- a/source/gui/widgets/listbox.cpp
+++ b/source/gui/widgets/listbox.cpp
@@ -1684,6 +1684,25 @@ namespace nana
 				return changed;
 			}
 
+			index_pairs pick_items() const
+			{
+				index_pairs results;
+				index_pair id;
+
+				for (auto& cat : categories_)
+				{
+					id.item = 0;
+					for (auto& m : cat.items)
+					{
+						results.push_back(id);  // absolute positions, no relative to display
+
+						++id.item;
+					}
+					++id.cat;
+				}
+				return results;
+			}
+
 			/// return absolute positions, no relative to display
 			/**
 			 * @param for_selection Indicates whether the selected items or checked items to be returned.
@@ -6098,6 +6117,12 @@ namespace nana
 		{
 			internal_scope_guard lock;
 			return !_m_ess().lister.active_sort(!freeze);
+		}
+
+		auto listbox::items() const -> index_pairs
+		{
+			internal_scope_guard lock;
+			return _m_ess().lister.pick_items();   // absolute positions, no relative to display
 		}
 
 		auto listbox::selected() const -> index_pairs


### PR DESCRIPTION
Hi, I had problems into getting all items from a listbox, so I came with this idea of contributing to the project. It's a very small change but I think it's very useful :).

If the functionality already exists let me know, I found only one way to reproduce what I wanted:
Select the category items and then get the selected items (which wasn't very intuitive at first and it works only for individual categories), like:
```c++
lb_listbox1->at(0).select(true);
listbox::index_pairs items = lb_listbox1->selected();
```

Now I can do this:
```c++
listbox::index_pairs items = lb_listbox1->items();
```

Anyway, It worked in my tests, feel free to edit/implement in your way, I just wanted to see this feature in the library. Thanks for your awesome job.