### PR TITLE
Now double click in spinbox select all the number (or text)

### DIFF
--- a/source/gui/widgets/spinbox.cpp
+++ b/source/gui/widgets/spinbox.cpp
@@ -559,7 +559,7 @@ namespace nana
 		
 		void drawer::dbl_click(graph_reference, const arg_mouse& arg)
 		{
-			if (impl_->mouse_button(arg, true))
+			if (impl_->editor()->select_word(arg))
 				api::dev::lazy_refresh();
 		}
 


### PR DESCRIPTION
Changed behavior of double-click event in spinbox control.
BEFORE: double-click was the same of click
NOW: double-click select all the number (or text) inside the spinbox