### PR TITLE
treebox::clear failed repair and arg_dropfiles::pos repair 

### DIFF
--- a/include/nana/gui/detail/window_manager.hpp
+++ b/include/nana/gui/detail/window_manager.hpp
@@ -137,6 +137,7 @@ namespace detail
 		bool enable_effects_bground(basic_window*, bool);
 
 		bool calc_window_point(basic_window*, nana::point&);
+		bool calc_screen_point(basic_window*, nana::point&);
 
 		root_misc* root_runtime(native_window) const;
 

--- a/include/nana/gui/widgets/detail/tree_cont.hpp
+++ b/include/nana/gui/widgets/detail/tree_cont.hpp
@@ -125,6 +125,8 @@ namespace detail
 			{
 				if(node)
 				{
+					if(node == &root_)
+						return true;
 					while(node->owner)
 					{
 						if(node->owner == &root_)

--- a/source/gui/detail/bedrock_windows.cpp
+++ b/source/gui/detail/bedrock_windows.cpp
@@ -1254,7 +1254,10 @@ namespace detail
 						if(msgwnd)
 						{
 							dropfiles.pos = pos;
-
+							
+							// ::DragQueryPoint(drop, &mswin_pos); Returns the location of the point dragged into the file window
+							// https://docs.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-dragquerypoint
+							wd_manager.calc_screen_point(root_runtime->window, dropfiles.pos);
 							wd_manager.calc_window_point(msgwnd, dropfiles.pos);
 							dropfiles.window_handle = msgwnd;
 

--- a/source/gui/detail/window_manager.cpp
+++ b/source/gui/detail/window_manager.cpp
@@ -1418,6 +1418,20 @@ namespace detail
 			}
 			return false;
 		}
+		bool window_manager::calc_screen_point(basic_window* wd, nana::point& pos) 
+		{
+						//Thread-Safe Required!
+			std::lock_guard<mutex_type> lock(mutex_);
+			if (impl_->wd_register.available(wd))
+			{
+				if(native_interface::calc_screen_point(wd->root, pos))
+				{
+					pos -= wd->pos_root;
+					return true;
+				}
+			}
+			return false;
+		}
 
 		root_misc* window_manager::root_runtime(native_window native_wd) const
 		{


### PR DESCRIPTION
The incoming node may be directly a pointer to the root node
传入节点有可能直接是根节点的指针