### PR TITLE
added a feature : disabling tabstop

### DIFF
--- a/include/nana/gui/detail/window_manager.hpp
+++ b/include/nana/gui/detail/window_manager.hpp
@@ -130,6 +130,7 @@ namespace detail
 		void capture_window(basic_window*, bool capture, bool ignore_children_if_captured);
 
 		void enable_tabstop(basic_window*);
+		void disable_tabstop(basic_window*);
 		basic_window* tabstop(basic_window*, bool forward) const;	//forward means move to next in logic.
 
 		void remove_trash_handle(thread_t tid);

--- a/include/nana/gui/programming_interface.hpp
+++ b/include/nana/gui/programming_interface.hpp
@@ -413,8 +413,8 @@ namespace api
 	 */
 	::std::unique_ptr<caret_interface> open_caret(window window_handle, bool disable_throw = false);
 
-	/// Enables that the user can give input focus to the specified window using TAB key.
-	void tabstop(window);
+	/// Determines whether the specified window can get a focus when TAB key is pressed.
+	void tabstop(window window_handle, const bool enable);
 
 	/// Enables or disables a window to receive a key_char event for pressing TAB key.
 	/*

--- a/source/gui/detail/window_manager.cpp
+++ b/source/gui/detail/window_manager.cpp
@@ -1318,6 +1318,17 @@ namespace detail
 			}
 		}
 
+		void window_manager::disable_tabstop(basic_window* wd)
+		{
+			std::lock_guard<mutex_type> lock(mutex_);
+			if (impl_->wd_register.available(wd) && (wd->flags.tab & detail::tab_type::tabstop))
+			{
+				auto& tabstop_enabled_windows = wd->root_widget->other.attribute.root->tabstop;
+				tabstop_enabled_windows.erase(std::find(tabstop_enabled_windows.begin(), tabstop_enabled_windows.end(), wd));
+				wd->flags.tab &= ~detail::tab_type::tabstop;
+			}			
+		}
+
 		// preconditions of get_tabstop: tabstop is not empty and at least one window is visible
 		basic_window* get_tabstop(basic_window* wd, bool forward)
 		{

--- a/source/gui/programming_interface.cpp
+++ b/source/gui/programming_interface.cpp
@@ -1270,9 +1270,12 @@ namespace api
 		return std::unique_ptr<caret_interface>{ p };
 	}
 
-	void tabstop(window wd)
+	void tabstop(window wd, const bool enable)
 	{
-		restrict::wd_manager().enable_tabstop(wd);
+		if (enable)
+			restrict::wd_manager().enable_tabstop(wd);
+		else
+			restrict::wd_manager().disable_tabstop(wd);
 	}
 
 	//eat_tabstop

--- a/source/gui/widgets/button.cpp
+++ b/source/gui/widgets/button.cpp
@@ -101,7 +101,7 @@ namespace nana
 			window wd = wdg;
 
 			api::dev::enable_space_click(wd, true);
-			api::tabstop(wd);
+			api::tabstop(wd, true);
 			api::effects_edge_nimbus(wd, effects::edge_nimbus::active);
 			api::effects_edge_nimbus(wd, effects::edge_nimbus::over);
 			api::dev::set_measurer(wd, &impl_->measurer);

--- a/source/gui/widgets/spinbox.cpp
+++ b/source/gui/widgets/spinbox.cpp
@@ -281,7 +281,7 @@ namespace nana
 				//Spinbox doesn't process the tabstop unlike other text editors.
 				//Otherwise it would bring a weird user experience.
 				//Issued by jk.
-				api::tabstop(wd);
+				api::tabstop(wd, true);
 				api::effects_edge_nimbus(wd, effects::edge_nimbus::active);
 				api::effects_edge_nimbus(wd, effects::edge_nimbus::over);
 				reset_text_area();

--- a/source/gui/widgets/textbox.cpp
+++ b/source/gui/widgets/textbox.cpp
@@ -76,7 +76,7 @@ namespace nana
 
 			_m_editor_area(graph.width(), graph.height());
 
-			api::tabstop(wd);
+			api::tabstop(wd, true);
 			api::eat_tabstop(wd, true);
 			api::effects_edge_nimbus(wd, effects::edge_nimbus::active);
 			api::effects_edge_nimbus(wd, effects::edge_nimbus::over);


### PR DESCRIPTION
There are widgets that always use tabstop feature (such as `button`, `textbox`, `spinbox`), because it is set at their creation time.
I think it is likely that someone might want to disable the tabstop feature for some widgets.
I got the idea from `eat_tabstop` api and changed `tabstop` function somewhat similar to that.

If nana library has already provided an api that does the same thing, please let me know.
(I'll use that instead and close this pull request)

