### PR TITLE
Improved dragdrop

### DIFF
--- a/include/nana/gui/dragdrop.hpp
+++ b/include/nana/gui/dragdrop.hpp
@@ -106,6 +106,7 @@ namespace nana
 		};
 
 		dragdrop(window source);
+		dragdrop(window source, bool show_icons);
 		~dragdrop();
 
 		/// Condition checker

--- a/include/nana/gui/dragdrop.hpp
+++ b/include/nana/gui/dragdrop.hpp
@@ -1,7 +1,7 @@
 /**
 *	Drag and Drop Implementation
 *	Nana C++ Library(http://www.nanapro.org)
-*	Copyright(C) 2018-2019 Jinhao(cnjinhao@hotmail.com)
+*	Copyright(C) 2018-2021 Jinhao(cnjinhao@hotmail.com)
 *
 *	Distributed under the Boost Software License, Version 1.0.
 *	(See accompanying file LICENSE_1_0.txt or copy at
@@ -100,6 +100,7 @@ namespace nana
 			data& operator=(data&& rhs);
 
 			void insert(std::filesystem::path);
+			const std::vector<std::filesystem::path> get();
 		private:
 			detail::dragdrop_data* real_data_;
 		};
@@ -119,7 +120,7 @@ namespace nana
 		 * Set a data generator. When drag begins, it is called to generate a data object for transferring.
 		 * @param generator It returns the data for transferring.
 		 */
-		void prepare_data(std::function<data()> generator);
+		void prepare_drop_data(std::function<data()> generator);
 
 		/// Drop handler
 		/**
@@ -130,6 +131,13 @@ namespace nana
 		 * @param finish_fn The drop handling function.
 		 */
 		void drop_finished(std::function<void(bool dropped, dnd_action executed_action, data& data_transferred)> finish_fn);
+
+		/// Recieve Drop Handler
+		/**
+		*  The recieve drop handler is called when another application drops data into the current window.
+		*  @param recieve_fn The recieve drop handling function.
+		*/
+		void receive_drop(std::function<void(dnd_action executed_action, data& data_recieved)> receive_fn);
 	private:
 		implementation* const impl_;
 	};

--- a/source/gui/dragdrop.cpp
+++ b/source/gui/dragdrop.cpp
@@ -240,6 +240,11 @@ namespace nana
 			return cRef;
 		}
 
+		bool simple_mode()
+		{
+			return simple_mode_;
+		}
+
 	private:
 		// IDropTarget
 		STDMETHODIMP DragEnter(IDataObject* data, DWORD grfKeyState, POINTL pt, DWORD* req_effect)
@@ -362,6 +367,7 @@ namespace nana
 
 			return S_OK;
 		}
+
 	private:
 		LONG ref_count_{ 1 };
 		bool const simple_mode_;		//Simple mode behaves the simple_dragdrop.
@@ -768,6 +774,11 @@ using win32_dropdata = win32com_iunknown<win32_dropdata_impl, IID_IDataObject>;
 			else
 			{
 				ddrop = dynamic_cast<dragdrop_target*>(i->second);
+				
+				if (simple_mode != ddrop->simple_mode())
+				{
+					throw std::runtime_error("Cannot mix dragdrop adn simple_dragdrop targets.");
+				}
 
 #ifdef NANA_WINDOWS
 				ddrop->AddRef();


### PR DESCRIPTION
- Added the ability for `dragdrop` to receive files.
- Renamed `dragdrop::prepare_data` to `prepare_drop_data` so that it states that it's for sending not receiving data.
- Made `dragdrop` only work for external transfers (see note-1), `simple_dragdrop` should be used for internal transfers.
- Added support to show file icons when `dragdrop` receives files (e.g. from explorer).
- Stopped `dragdrop` and `simple_dragdrop` being created on the same `form` (see note-2)

These changes are for windows only.
I did try to do it for linux as well, but it wasn't clear where to start, and the documentation for xdnd was lacking.

_note-1:_
This removes an error caused by itself.
Although sometimes when using visual studio 2019 with the debugger attached only, the program may either freeze or throw an error in native code.

_note-2:_
This throws an error instead of allowing both to succeed, but with only one actually working. So it is more clear to the user.