### PR TITLE
arrowhead direction::east implementation

### DIFF
--- a/source/gui/element.cpp
+++ b/source/gui/element.cpp
@@ -416,6 +416,27 @@ namespace nana
 						pixels -= 2;
 					}
 				}
+				break;
+				case direction::east:
+				{
+					for (int i = 0; i < 4; ++i)
+					{
+						graph.set_pixel(x, y);
+						graph.set_pixel(x + 1, y);
+						++x;
+						++y;
+					}
+
+					--x;
+					for (int i = 0; i < 3; ++i)
+					{
+						graph.set_pixel(x, y);
+						graph.set_pixel(x - 1, y);
+						--x;
+						++y;
+					}
+				}
+				break;
 				default:break;
 				}
 				return true;


### PR DESCRIPTION
Recently, I found out that the implementation for the arrowhead style was missing. 
So I added it (only for the east direction).
Now users can use `arrowhead` submenu arrow style.