### PR TITLE
listbox scheme additions (item border & category)

### DIFF
--- a/include/nana/gui/widgets/listbox.hpp
+++ b/include/nana/gui/widgets/listbox.hpp
@@ -1220,11 +1220,13 @@ namespace nana
 				: public widget_geometrics
 			{
 				color_proxy column_separator{ static_cast<color_argb>(0xEBF4F9) };	///< Color of item column separator
+				color_proxy cat_fgcolor{ static_cast<color_argb>(0x3399) };
 				color_proxy header_bgcolor{static_cast<color_rgb>(0xf1f2f4)};
 				color_proxy header_fgcolor{ colors::black };
 				color_proxy header_grabbed{ static_cast<color_rgb>(0x8BD6F6)};
 				color_proxy header_floated{ static_cast<color_rgb>(0xBABBBC)};
 				color_proxy item_selected{ static_cast<color_rgb>(0xCCE8FF) };
+				color_proxy item_selected_border{ static_cast<color_rgb>(0x99DEFD) };
 				color_proxy item_highlighted{ static_cast<color_rgb>(0xE5F3FF) };
 
 				color_proxy selection_box{ static_cast<color_rgb>(0x3399FF) };	///< Color of selection box border.


### PR DESCRIPTION
Currently, the color of the item selection border, and the category foreground color are hard-coded, limiting the ways in which the listbox appearance can be changed (for example, a dark background can't be used). This PR solves the issue by making those colors modifiable by the user.