### PR TITLE
Fix warnings in clang

### DIFF
--- a/include/nana/pat/cloneable.hpp
+++ b/include/nana/pat/cloneable.hpp
@@ -114,7 +114,7 @@ namespace nana{ namespace pat{
 		{
 			if(r.cwrapper_)
 			{
-				cwrapper_ = std::move(std::shared_ptr<cloneable_interface>(r.cwrapper_->clone(), detail::cloneable_interface_deleter{}));
+				cwrapper_ = std::shared_ptr<cloneable_interface>(r.cwrapper_->clone(), detail::cloneable_interface_deleter{});
 				fast_ptr_ = reinterpret_cast<base_t*>(cwrapper_->get());
 			}
 		}

--- a/source/charset.cpp
+++ b/source/charset.cpp
@@ -873,7 +873,7 @@ namespace nana
 			virtual std::string && str_move()
 			{
 				if(is_unicode_)
-					data_ = std::move(str());
+					data_ = str();
 				return std::move(data_);
 			}
 
@@ -983,7 +983,7 @@ namespace nana
 
 			virtual std::wstring&& wstr_move()
 			{
-				wdata_for_move_ = std::move(wstr());
+				wdata_for_move_ = wstr();
 				return std::move(wdata_for_move_);
 			}
 		private:
@@ -1020,7 +1020,7 @@ namespace nana
 
 			virtual std::string && str_move()
 			{
-				data_for_move_ = std::move(str());
+				data_for_move_ = str();
 				return std::move(data_for_move_);
 			}
 

--- a/source/detail/platform_abstraction.cpp
+++ b/source/detail/platform_abstraction.cpp
@@ -374,7 +374,7 @@ namespace nana
 			std::unique_ptr<FT_UInt[]> glyph_indexes(new FT_UInt[len]);
 
 			//Don't reverse the string
-			_m_reorder_reshaping(std::wstring_view{str, len}, false, [&,xft, str](const wchar_t* p, std::size_t size, const wchar_t* /*pstr*/) mutable{
+			_m_reorder_reshaping(std::wstring_view{str, len}, false, [&,xft](const wchar_t* p, std::size_t size, const wchar_t* /*pstr*/) mutable{
 				while(true)
 				{
 					auto preferred = _m_scan_fonts(xft, p, size, glyph_indexes.get());


### PR DESCRIPTION
Remove std::move from temporary variables
Do not capture unused variable