### PR TITLE
convert xk_home xk_end correctly

### DIFF
--- a/source/gui/detail/bedrock_posix.cpp
+++ b/source/gui/detail/bedrock_posix.cpp
@@ -435,6 +435,10 @@ namespace detail
 			keysym = keyboard::os_shift; break;
 		case XK_Control_L: case XK_Control_R: //ctrl
 			keysym = keyboard::os_ctrl;	break;
+		case XK_Home:
+			keysym = keyboard::os_home; break;
+		case XK_End:
+			keysym = keyboard::os_end; break;
 		default:
 			do
 			{


### PR DESCRIPTION
Home and End keys don't work on linux, they do nothing.
Seems like a correct fix