### PR TITLE
Added support for setting arbitrary-format icons on Windows

### DIFF
--- a/source/paint/image.cpp
+++ b/source/paint/image.cpp
@@ -50,13 +50,32 @@ namespace paint
 #if defined(NANA_WINDOWS)
 	HICON image_accessor::icon(const nana::paint::image& img)
 	{
+		if (img.empty())
+			return nullptr;
+
 		auto ico_res = dynamic_cast<paint::detail::image_ico_resource*>(img.image_ptr_.get());
 		if (ico_res)
 			return reinterpret_cast<HICON>(ico_res->native_handle());
 
-		auto ico = dynamic_cast<paint::detail::image_ico*>(img.image_ptr_.get());
-		if (ico)
-			return reinterpret_cast<HICON>(ico->native_handle());
+		auto size = img.size();
+		
+		//Construct pixel buffer and swap blue and red channels for CreateIcon
+		std::vector<uint8_t> pixels(size.width * size.height * 4);
+		for (std::size_t i = 0; i < pixels.size(); i += 4)
+		{
+			auto row = (size_t) std::floor((i / 4) / size.height);
+			auto column = (i / 4) % size.width;
+			auto color = img.pxbuf()[row][column];
+
+			pixels[i + 0] = color.element.blue;
+			pixels[i + 1] = color.element.green;
+			pixels[i + 2] = color.element.red;
+			pixels[i + 3] = color.element.alpha_channel;
+		}
+
+		auto icon = CreateIcon(GetModuleHandle(NULL), size.width, size.height, 1, 32, NULL, &pixels[0]);
+		if (icon)
+			return icon;
 
 		return nullptr;
 	}


### PR DESCRIPTION
Currently on the Windows platform, window icons must either be a .ico file, a ICO encoded buffer or a resource icon.

To me, this doesn't make much sense, as the Win32 API easily supports creating icons on the fly straight from pixel data.

So in this PR I added support for creating icons directly from the pixel data stored in `nana::paint::image`.
The point of this is that now one can easily set any bmp, png or jpeg (provided png and jpeg are enabled, respectively) as icons as well.

On that note I also wanted to say that the pixel buffer can be quite difficult to get pixel data from. Maybe the API could be improved in that regard.