### PR TITLE
textbox focused border can now be disabled

### DIFF
--- a/include/nana/gui/widgets/skeletons/text_editor.hpp
+++ b/include/nana/gui/widgets/skeletons/text_editor.hpp
@@ -223,6 +223,9 @@ namespace nana::widgets::skeletons
 		bool try_refresh();
 
 		std::shared_ptr<scroll_operation_interface> scroll_operation() const;
+
+		// sets whether the focused border is shown
+		void enable_focused_border(bool);
 	private:
 		nana::color _m_draw_colored_area(paint::graphics& graph, const std::pair<std::size_t,std::size_t>& row, bool whole_line);
 		std::vector<upoint> _m_render_text(const ::nana::color& text_color);

--- a/include/nana/gui/widgets/textbox.hpp
+++ b/include/nana/gui/widgets/textbox.hpp
@@ -296,6 +296,9 @@ namespace nana
 
 		/// Sets the padding area around the content.
 		textbox& padding(unsigned top, unsigned right, unsigned bottom, unsigned left) noexcept;
+
+		// sets whether the focused border is shown
+		void enable_border_focused(bool);
 	protected:
 		//Overrides widget's virtual functions
 		native_string_type _m_caption() const noexcept override;

--- a/source/gui/widgets/skeletons/text_editor.cpp
+++ b/source/gui/widgets/skeletons/text_editor.cpp
@@ -484,6 +484,7 @@ namespace nana::widgets::skeletons
 	{
 		undoable<command>	undo;			//undo command
 		renderers			customized_renderers;
+		bool show_focused_border = true; ///< Whether the text_editor shows a border when it is focused via being clicked on
 		std::vector<upoint> text_position;	//positions of text since last rendering.
 		int text_position_origin{ -1 };	//origin when last text_exposed
 
@@ -1982,6 +1983,11 @@ namespace nana::widgets::skeletons
 		return impl_->cview->scroll_operation();
 	}
 
+	void text_editor::enable_focused_border(bool enable)
+	{
+		impl_->show_focused_border = enable;
+	}
+
 	void text_editor::draw_corner()
 	{
 		impl_->cview->draw_corner(graph_);
@@ -2561,7 +2567,15 @@ namespace nana::widgets::skeletons
 			else
 			{
 				::nana::facade<element::border> facade;
-				facade.draw(graph_, _m_bgcolor(), api::fgcolor(this->window_), ::nana::rectangle{ api::window_size(this->window_) }, api::element_state(this->window_));
+
+				if (this->impl_->show_focused_border)
+				{
+					facade.draw(graph_, _m_bgcolor(), api::fgcolor(this->window_), ::nana::rectangle{ api::window_size(this->window_) }, api::element_state(this->window_));
+				}
+				else
+				{
+					facade.draw(graph_, _m_bgcolor(), api::fgcolor(this->window_), ::nana::rectangle{ api::window_size(this->window_) }, element_state::normal);
+				}
 			}
 
 			if (!attributes_.line_wrapped)

--- a/source/gui/widgets/textbox.cpp
+++ b/source/gui/widgets/textbox.cpp
@@ -910,6 +910,13 @@ namespace nana
 			return *this;
 		}
 
+		void textbox::enable_border_focused(bool enable)
+		{
+			internal_scope_guard lock;
+			auto editor = get_drawer_trigger().editor();
+			editor->enable_focused_border(enable);
+		}
+
 		//Override _m_caption for caption()
 		auto textbox::_m_caption() const noexcept -> native_string_type
 		{


### PR DESCRIPTION
Added a new function to `textbox` and `text_editor` so that the border that is shown when the widget is clicked on can be disabled.
The need for this was discussed in #656.

Example use to disable it:
```cpp
form fm;
textbox tb{ fm };

tb.enable_border_focused(false);
```
The name of the function may need to be changed though, to maybe something like `enable_focused_border_when_clicked`, so it's more clear.