### PR TITLE
Removed char8_t support from nana::menu since it was broken and unused.

### DIFF
--- a/include/nana/gui/widgets/menu.hpp
+++ b/include/nana/gui/widgets/menu.hpp
@@ -49,9 +49,7 @@ namespace nana
 					bool		checked() const;
 
 					item_proxy& text(std::string title_utf8);
-#ifdef __cpp_char8_t
-					item_proxy& text(std::u8string_view title);
-#endif
+
 					std::string text() const;
 
 					std::size_t index() const;
@@ -110,9 +108,6 @@ namespace nana
 				virtual void item(graph_reference, const nana::rectangle&, const attr&) = 0;
 				virtual void item_image(graph_reference, const nana::point&, unsigned image_px, const paint::image&) = 0;
 				virtual void item_text(graph_reference, const nana::point&, const std::string&, unsigned text_pixels, const attr&) = 0;
-#ifdef __cpp_char8_t
-				virtual void item_text(graph_reference, const nana::point&, std::u8string_view, unsigned text_pixels, const attr&) = 0;
-#endif
 				virtual void sub_arrow(graph_reference, const nana::point&, unsigned item_pixels, const attr&) = 0;
 			};
 	}//end namespace drawerbase::menu
@@ -153,9 +148,6 @@ namespace nana
 		void close();
 		void image(std::size_t pos, const paint::image& icon);
 		void text(std::size_t pos, std::string text_utf8);
-#ifdef __cpp_char8_t
-		void text(std::size_t pos, std::u8string_view text);
-#endif
 		std::string text(std::size_t pos) const;
 		void check_style(std::size_t pos, checks);
 		void checked(std::size_t pos, bool);

--- a/source/gui/widgets/menu.cpp
+++ b/source/gui/widgets/menu.cpp
@@ -147,17 +147,6 @@ namespace nana
 				auto wstr = to_wstring(text);
 				tr.render(pos, { wstr.c_str(), wstr.length() }, text_pixels, paint::text_renderer::mode::truncate_with_ellipsis);
 			}
-#ifdef __cpp_char8_t
-			void item_text(graph_reference graph, const nana::point& pos, std::u8string_view title, unsigned text_pixels, const attr& at) override
-			{
-				graph.palette(true, at.enabled ? colors::black : colors::gray_border);
-				nana::paint::text_renderer tr(graph);
-
-				auto wstr = to_wstring(title);
-				tr.render(pos, { wstr.c_str(), wstr.length() }, text_pixels, paint::text_renderer::mode::truncate_with_ellipsis);
-			}
-#endif
-
 
 			void sub_arrow(graph_reference graph, const nana::point& pos, unsigned pixels, const attr&) override
 			{
@@ -339,14 +328,6 @@ namespace nana
 			menu_->text(pos_, title);
 			return *this;
 		}
-
-#ifdef __cpp_char8_t
-		menu_item_type::item_proxy& menu_item_type::item_proxy::text(std::u8string_view title)
-		{
-			menu_->text(pos_, to_string(title));
-			return *this;
-		}
-#endif
 
 		std::string menu_item_type::item_proxy::text() const
 		{
@@ -1250,13 +1231,6 @@ namespace nana
 		{
 			impl_->mbuilder.data().items.at(index)->text.swap(text_utf8);
 		}
-
-#ifdef __cpp_char8_t
-		void menu::text(std::size_t index, std::u8string_view text)
-		{
-			impl_->mbuilder.data().items.at(index)->text = to_string(text);
-		}
-#endif
 
 		std::string menu::text(std::size_t index) const
 		{


### PR DESCRIPTION
Fixes #660.