### PR TITLE
Fix compilation error and run-time error with VS2022-17.1 (v143) and c++std20

### DIFF
--- a/source/gui/detail/window_manager.cpp
+++ b/source/gui/detail/window_manager.cpp
@@ -1353,19 +1353,19 @@ namespace detail
 			internal_scope_guard lock;
 
 			auto& safe_place = impl_->safe_place.table();
-			for (auto i = safe_place.begin(); i != safe_place.end();)
+			int i=0;
+            while (i < safe_place.size()) 
 			{
-				if (i->first->thread_id == thread_id)
+                if (safe_place[i].first->thread_id == thread_id)
 				{
-					auto functions = std::move(i->second);
-					i = safe_place.erase(i);
+					auto functions = std::move(safe_place[i].second);
+                    safe_place.erase(safe_place.begin()+i);
 
 					for (auto& fn : functions)
 						fn();
-				}
-				else
-					++i;
-			}
+				} else
+                    ++i;
+			} 
 		}
 
 		//updates the window elements when DPI is changed.

--- a/source/paint/pixel_buffer.cpp
+++ b/source/paint/pixel_buffer.cpp
@@ -1565,8 +1565,8 @@ namespace nana{	namespace paint
 		    int bsq = b * b;
 		    int xa, ya;
 
-		    pixel({x, y+b}, col);
-		    pixel({x, y-b}, col);
+		    pixel(nana::point ( x, y + b ), col);
+            pixel(nana::point ( x, y - b ), col);
 
 		    wx = 0;
 		    wy = b;
@@ -1596,8 +1596,8 @@ namespace nana{	namespace paint
 		        pixel({x-wx, y+wy}, col);
 		    }
 
-		    pixel({x+a, y}, col);
-		    pixel({x-a, y}, col);
+		    pixel(nana::point ( x + a, y ), col);
+            pixel(nana::point ( x - a, y ), col);
 
 		    wx = a;
 		    wy = 0;


### PR DESCRIPTION
Hi,
please, don't take too serious this - you may have better solutions.

The first is a variation on #664 and #665 becouse of compilation error. You may want to use std::round or simmilar if needed.

The second is a fix for a run-error (crash) that invalidate the` .end()` after an` .erase()`. I don't know why, but it appear in `release `and `debug `mode. The debuger showed undefined `end()`, which coincide with the documentation. I used trivial index. Not very elegant but works.