### PR TITLE
return value in all cases

### DIFF
--- a/include/nana/gui/detail/general_events.hpp
+++ b/include/nana/gui/detail/general_events.hpp
@@ -201,6 +201,7 @@ namespace nana
 			{
 				static_assert(!std::is_invocable_v<Function, Arg&>, "The type of parameter of event handler must be immutable for the argument. E.g. void(Arg&) is not acceptable.");
 				static_assert(std::is_invocable_v<Function, Arg&>, "The type of parameter of event handler doesn't match the event argument type.");
+				return nullptr;
 			}
 		}
 

--- a/include/nana/gui/widgets/listbox.hpp
+++ b/include/nana/gui/widgets/listbox.hpp
@@ -855,7 +855,7 @@ namespace nana
 				 */
 				item_proxy & select(bool sel, bool scroll_view = false);
 
-				/// Determines whether he item is selected
+				/// Determines whether the item is selected
 				bool selected() const;
 
 				item_proxy & bgcolor(const nana::color&);


### PR DESCRIPTION
Hi, I'm compiling nana with gcc 13.2 (from msys2 on windows) and std=c++23. Using the switch -Werror=return-type I force to errors the warnings of methods not returning a value through all paths (normally allowed for compatibility with C). So I get an error in the method on general_events.hpp :
```
template<typename Function>
event_handle connect_unignorable(Function && fn, bool in_front = false)
```
which had no return statement in the else branch. Honestly I'm not sure if I'm returning a right/meaningful value, but it then compiles and works normally.
I've also fixed a tiny typo.