### PR TITLE
add single click event handler to listbox

### DIFF
--- a/include/nana/gui/widgets/listbox.hpp
+++ b/include/nana/gui/widgets/listbox.hpp
@@ -801,6 +801,8 @@ namespace nana
 				void mouse_leave(graph_reference, const arg_mouse&)	override;
 				void mouse_down(graph_reference, const arg_mouse&)	override;
 				void mouse_up(graph_reference, const arg_mouse&)	override;
+				void click_common(graph_reference);
+				void click(graph_reference, const arg_click&)	override;
 				void dbl_click(graph_reference, const arg_mouse&)	override;
 				void resized(graph_reference, const arg_resized&)		override;
 				void key_press(graph_reference, const arg_keyboard&)	override;

--- a/source/gui/widgets/listbox.cpp
+++ b/source/gui/widgets/listbox.cpp
@@ -4533,8 +4533,8 @@ namespace nana
 					api::dev::lazy_refresh();
 				}
 			}
-
-			void trigger::dbl_click(graph_reference graph, const arg_mouse&)
+			
+			void trigger::click_common(graph_reference graph)
 			{
 				using parts = essence::parts;
 
@@ -4580,6 +4580,16 @@ namespace nana
 						api::dev::lazy_refresh();
                     }
 				}
+			}
+			
+			void trigger::click(graph_reference graph, const arg_click&)
+			{
+				click_common(graph);
+			}
+
+			void trigger::dbl_click(graph_reference graph, const arg_mouse&)
+			{
+				click_common(graph);
 			}
 
 			void trigger::resized(graph_reference graph, const arg_resized&)


### PR DESCRIPTION
Hi, I've recently had the necessity, in a listbox, of managing not only the double click on row items, but also the single click. So I've tried to make a simple thing : I duplicated the code for the dbl_click handler in a click handler.
I've seen that it works : it correctly reacts to single clicks. To avoid code duplication I've put the common instructions in a central, private method.
One possible issue that remains (but I've no idea on how to fix it) is that now, whenever I double click, both events get called : double click and single click. Could single click be just called with single clicks ?