### PR TITLE
marks dpi todo in Develop 1.8

### DIFF
--- a/build/vc2022/nana.vcxproj
+++ b/build/vc2022/nana.vcxproj
@@ -515,6 +515,12 @@
     <ClInclude Include="..\..\include\nana\internationalization.hpp" />
     <ClInclude Include="..\..\include\nana\key_type.hpp" />
     <ClInclude Include="..\..\include\nana\paint\font_info.hpp" />
+    <ClInclude Include="..\..\include\nana\paint\graphics.hpp" />
+    <ClInclude Include="..\..\include\nana\paint\image.hpp" />
+    <ClInclude Include="..\..\include\nana\paint\image_process_interface.hpp" />
+    <ClInclude Include="..\..\include\nana\paint\image_process_selector.hpp" />
+    <ClInclude Include="..\..\include\nana\paint\pixel_buffer.hpp" />
+    <ClInclude Include="..\..\include\nana\paint\text_renderer.hpp" />
     <ClInclude Include="..\..\include\nana\traits.hpp" />
     <ClInclude Include="..\..\include\nana\unicode_bidi.hpp" />
     <ClInclude Include="..\..\include\nana\verbose_preprocessor.hpp" />

--- a/build/vc2022/nana.vcxproj.filters
+++ b/build/vc2022/nana.vcxproj.filters
@@ -50,6 +50,9 @@
     <Filter Include="Include\gui\widgets">
       <UniqueIdentifier>{0e6a58ab-652c-45d7-b9aa-8d9f2fa80ea1}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Include\paint">
+      <UniqueIdentifier>{fc600cb9-126e-4bda-9ba6-de1915d3b41b}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\source\basic_types.cpp">
@@ -456,6 +459,24 @@
     <ClInclude Include="..\..\include\nana\paint\font_info.hpp" />
     <ClInclude Include="..\..\source\paint\detail\image_format_defs.hpp" />
     <ClInclude Include="..\..\source\paint\detail\image_gif.hpp" />
+    <ClInclude Include="..\..\include\nana\paint\graphics.hpp">
+      <Filter>Include\paint</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\nana\paint\image.hpp">
+      <Filter>Include\paint</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\nana\paint\image_process_interface.hpp">
+      <Filter>Include\paint</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\nana\paint\image_process_selector.hpp">
+      <Filter>Include\paint</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\nana\paint\pixel_buffer.hpp">
+      <Filter>Include\paint</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\nana\paint\text_renderer.hpp">
+      <Filter>Include\paint</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\include\nana\pop_ignore_diagnostic">

--- a/include/nana/gui/detail/window_manager.hpp
+++ b/include/nana/gui/detail/window_manager.hpp
@@ -129,7 +129,7 @@ namespace nana::detail
 		void set_safe_place(basic_window* wd, std::function<void()>&& fn);
 		void call_safe_place(thread_t thread_id);
 
-		//updates the window elements when DPI is changed.
+		/// \todo: generalize dpi to v2 awareness - updates the window elements when DPI is changed.
 		void update_dpi(basic_window*);
 	private:
 		void _m_disengage(basic_window*, basic_window* for_new);

--- a/include/nana/gui/msgbox.hpp
+++ b/include/nana/gui/msgbox.hpp
@@ -203,7 +203,7 @@ namespace nana
 			text& operator=(const text&) = delete;
 		public:
 			text(::std::string label, ::std::string init_text = ::std::string());
-			text(::std::string label, std::vector<::std::string>);
+			text(::std::string label, std::vector<::std::string> options);
 
 			~text();
 
@@ -254,7 +254,7 @@ namespace nana
 		{
 			struct implement;
 		public:
-			path(::std::string label, const ::nana::filebox&);
+			path(::std::string label, const ::nana::filebox& f_box);
 			~path();
 
 			::std::string value() const;
@@ -266,12 +266,12 @@ namespace nana
 			std::unique_ptr<implement> impl_;
 		};
 
-		inputbox(window owner,     ///< A handle to an owner window (just a parent form or widget works)
+		inputbox(window owner,     ///< A handle to an owner window (parent form or widget)
 		         ::std::string description,   ///< tells users what the purpose for the input. It can be a formatted-text.
                  ::std::string title = ::std::string()  ///< The title for the inputbox.
         );
 
-		/// shows images at left/right side of inputbox
+		/// shows images at left or right side of the inputbox
 		void image(::nana::paint::image image,      ///< The image
 		           bool is_left,      ///< true to place the image at left side, false to the right side
 		           const rectangle& valid_area = {} ///< The area of the image to be displayed

--- a/include/nana/gui/programming_interface.hpp
+++ b/include/nana/gui/programming_interface.hpp
@@ -509,6 +509,7 @@ namespace api
 	 */
 	::std::optional<std::pair<::nana::size, ::nana::size>> content_extent(window wd, unsigned limited_px, bool limit_width);
 
+	/// \todo: generalize dpi to v2 awareness
 	unsigned screen_dpi(bool x_requested);
 
 	std::size_t window_dpi(window);

--- a/include/nana/gui/widgets/widget.hpp
+++ b/include/nana/gui/widgets/widget.hpp
@@ -75,6 +75,7 @@ namespace nana
 		void cursor(nana::cursor);
 		nana::cursor cursor() const;		///< Retrieves the shape of cursor
 
+		/// \todo: generalize dpi to v2 awareness
 		void typeface(const paint::font_info&);	///< Sets font, the font will be scaled with the DPI of the window.
 		void typeface(const paint::font& font);	///< Sets font
 		paint::font typeface() const;

--- a/include/nana/paint/graphics.hpp
+++ b/include/nana/paint/graphics.hpp
@@ -40,6 +40,8 @@ namespace nana
 			font(drawable_type);
 			font(const font&);
 
+			/// \todo: generalize dpi to v2 awareness
+
 			/// creates a font object.
 			/// @param info Specifies the font family, size and styles.
 			/// @param dpi Specifies the DPI for scaling the font, 0 indicates the system DPI.

--- a/source/detail/platform_abstraction.cpp
+++ b/source/detail/platform_abstraction.cpp
@@ -1153,7 +1153,7 @@ namespace nana
 
 		//end class revertible_mutex
 
-
+    /// \todo: generalize dpi to v2 awareness
 	struct platform_runtime
 	{
 		platform_abstraction::revertible_mutex mutex;
@@ -1283,6 +1283,7 @@ namespace nana
 		return data::storage->mutex;
 	}
 
+	/// \todo: generalize dpi to v2 awareness
 	double platform_abstraction::font_default_pt()
 	{
 #ifdef NANA_WINDOWS
@@ -1344,6 +1345,7 @@ namespace nana
 		platform_storage().dpi = dpi;
 	}
 
+	/// \todo: generalize dpi to v2 awareness
 	std::size_t platform_abstraction::current_dpi()
 	{
 		return platform_storage().dpi;
@@ -1425,7 +1427,7 @@ namespace nana
 		}
 #endif
 	}
-
+	/// \todo: generalize dpi to v2 awareness
 	unsigned platform_abstraction::screen_dpi(bool x_requested)
 	{
 #ifdef NANA_WINDOWS

--- a/source/detail/platform_abstraction.hpp
+++ b/source/detail/platform_abstraction.hpp
@@ -61,6 +61,9 @@ namespace nana
 		static void font_languages(const std::string&);
 		static ::std::shared_ptr<font> default_font(const ::std::shared_ptr<font>&);
 
+		/// \todo: generalize dpi to v2 awareness
+
+		/// 'manuallay' set the current system DPI, this is used for DPI scaling.
 		static void set_current_dpi(std::size_t dpi);
 		static std::size_t current_dpi();
 

--- a/source/gui/detail/bedrock_windows.cpp
+++ b/source/gui/detail/bedrock_windows.cpp
@@ -40,6 +40,7 @@
 #	define WM_MOUSEHWHEEL	0x020E
 #endif
 
+/// \todo: generalize dpi to v2 awareness
 #ifndef WM_DPICHANGED
 #	define WM_DPICHANGED 0x02E0
 #endif
@@ -231,6 +232,7 @@ namespace detail
 		restrict::imm_get_composition_string = reinterpret_cast<restrict::imm_get_composition_string_type>(
 				::GetProcAddress(imm32, "ImmGetCompositionStringW"));
 
+		/// \todo: generalize dpi to v2 awareness
 		platform_abstraction::set_current_dpi(detail::native_interface::system_dpi());
 	}
 
@@ -808,7 +810,7 @@ namespace detail
 						i->second();
 				}
 				break;
-			case WM_DPICHANGED:
+			case WM_DPICHANGED:  /// \todo: generalize dpi to v2 awareness
 				wd_manager.update_dpi(msgwnd);
 				{
 				

--- a/source/gui/detail/window_manager.cpp
+++ b/source/gui/detail/window_manager.cpp
@@ -1368,7 +1368,7 @@ namespace detail
 			}
 		}
 
-		//updates the window elements when DPI is changed.
+		/// \todo: generalize dpi to v2 awareness - updates the window elements when DPI is changed.
 		void window_manager::update_dpi(basic_window* wd)
 		{
 			internal_scope_guard lock;

--- a/source/gui/msgbox.cpp
+++ b/source/gui/msgbox.cpp
@@ -1,17 +1,18 @@
 /**
  *	A Message Box Class
  *	Nana C++ Library(http://www.nanapro.org)
- *	Copyright(C) 2003-2020 Jinhao(cnjinhao@hotmail.com)
+ *	Copyright(C) 2003-2024 Jinhao(cnjinhao@hotmail.com)
  *
  *	Distributed under the Boost Software License, Version 1.0.
  *	(See accompanying file LICENSE_1_0.txt or copy at
  *	http://www.boost.org/LICENSE_1_0.txt)
  *
  *	@file nana/gui/msgbox.hpp
- *	@Contributors
+ *	@contributors
  *		James Bremner
  *		Ariel Vina-Rodriguez
  */
+
 #define NOMINMAX
 #include <algorithm>  // max
 #include <functional>
@@ -473,15 +474,14 @@ namespace nana
 	//end class msgbox
 
 
-	//class inputbox todo: add schema
-
+	/// class inputbox todo: add schema
 	class inputbox_window
 		: public ::nana::form
 	{
 	public:
 		inputbox_window(window owner,
-		                paint::image (&imgs)[4],             ///< 4 ref to images
-		                ::nana::rectangle (&valid_areas)[4],
+		                paint::image (&imgs)[4],              ///< 4 ref to images
+		                ::nana::rectangle (&valid_areas)[4],  ///< 4 ref to valid areas
 		                const ::std::string & description,
 		                const ::std::string& title,
 		                std::size_t contents,

--- a/source/gui/place.cpp
+++ b/source/gui/place.cpp
@@ -978,7 +978,7 @@ namespace nana
 
 				if (1 == set_weight)
 				{
-					//avoid deviation in dpi scaling.
+					/// \todo: generalize dpi to v2 awareness, avoid deviation in dpi scaling.
 					if (96 != dm.dpi)
 						this->weight.assign(static_cast<int>(fv * 96 / dm.dpi) + 1);
 					else

--- a/source/gui/place_parts.hpp
+++ b/source/gui/place_parts.hpp
@@ -475,7 +475,7 @@ namespace nana
 			}moves_;
 		};//class dockarea
 
-
+		/// \todo: generalize dpi to v2 awareness
 		struct display_metrics
 		{
 			std::size_t dpi;

--- a/source/gui/programming_interface.cpp
+++ b/source/gui/programming_interface.cpp
@@ -1499,6 +1499,7 @@ namespace api
 		return false;
 	}
 
+	/// \todo: generalize dpi to v2 awareness
 	void typeface(window wd, const nana::paint::font_info& fi)
 	{
 		internal_scope_guard lock;

--- a/source/gui/screen.cpp
+++ b/source/gui/screen.cpp
@@ -74,6 +74,7 @@ namespace nana
 	::nana::size screen::desktop_size()
 	{
 #if defined(NANA_WINDOWS)
+		/// \todo: add to dpi_function GetSystemMetricsForDpi and replace this
 		auto w = static_cast<size::value_type>(::GetSystemMetrics(SM_CXVIRTUALSCREEN));
 		auto h = static_cast<size::value_type>(::GetSystemMetrics(SM_CYVIRTUALSCREEN));
 		return{w, h};

--- a/source/gui/widgets/widget.cpp
+++ b/source/gui/widgets/widget.cpp
@@ -116,6 +116,7 @@ namespace nana
 			_m_cursor(cur);
 		}
 
+		/// \todo: generalize dpi to v2 awareness
 		void widget::typeface(const paint::font_info& fi)
 		{
 			api::typeface(handle(), fi);

--- a/source/paint/graphics.cpp
+++ b/source/paint/graphics.cpp
@@ -124,6 +124,7 @@ namespace paint
 				impl_->real_font = rhs.impl_->real_font;
 		}
 
+		/// \todo: generalize dpi to v2 awareness
 		font::font(const font_info& fi, std::size_t dpi):
 			impl_(new impl_type)
 		{

--- a/source/system/platform.cpp
+++ b/source/system/platform.cpp
@@ -104,6 +104,7 @@ namespace system
 	bool get_async_mouse_state(int button)
 	{
 #if defined(NANA_WINDOWS)
+		/// \todo: add to dpi_function GetSystemMetricsForDpi and replace this
 		bool swap = (::GetSystemMetrics(SM_SWAPBUTTON) != 0);
 		switch(button)
 		{


### PR DESCRIPTION
# core dpi dependencies / documents changes to do in:
**`source/gui/detail/native_window_interface.cpp`**  **

**`source/detail/platform_abstraction.hpp`**
**`source/detail/platform_abstraction.cpp`** ** (implements dpi_scale, etc. based on SystemParametersInfo, native_window_interface )

**`source/gui/detail/bedrock_windows.cpp`** (responds to WM_DPICHANGED with wd_manager.update_dpi(msgwnd) to update SetWindowPos of root_window )

**`include/nana/paint/graphics.hpp`**
**`source/paint/graphics.cpp`**   ** (uses: platform_abstraction)

`include/nana/gui/detail/window_manager.hpp` (not really)
`source/gui/detail/window_manager.cpp` (uses native_interface::, graphics)

`include/nana/gui/programming_interface.hpp` (not really, but part of API)
`source/gui/programming_interface.cpp ` (uses platform_abstraction::, graphics; interface_type::window_dp)



source/gui/place.cpp  ( ?? why ? )
source/gui/place_parts.hpp   ( ?? why ? )

source/gui/screen.cpp ( ? uses ::GetSystemMetrics directly )
source/system/platform.cpp ( ? uses ::GetSystemMetrics directly )

source/gui/widgets/widget.cpp  (not really)